### PR TITLE
Introduce a logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ htmlcov
 secrets.py
 
 *.lock
+src/forklift.log*

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -12,7 +12,6 @@ Arguments:
   <path>       an optional path to pass in so you can run a certain directory
 forklift 🚜
 '''
-
 import logging.config
 import sys
 from docopt import docopt
@@ -42,17 +41,30 @@ def _setup_logging():
             }
         },
         'handlers': {
-            'detailed_handler': {
+            'detailed_console_handler': {
                 'level': 'DEBUG',
                 'class': 'logging.StreamHandler',
                 'formatter': 'detailed_formatter',
                 'stream': 'ext://sys.stdout'
+            },
+            'detailed_file_handler': {
+                'level': 'DEBUG',
+                'class': 'logging.handlers.TimedRotatingFileHandler',
+                'filename': 'forklift.log',
+                'when': 'D',
+                'interval': '1',
+                'backupCount': '7',
+                'formatter': 'detailed_formatter'
             }
         },
         'loggers': {
-            '': {
-                'handlers': ['detailed_handler'],
+            'console': {
+                'handlers': ['detailed_console_handler'],
                 'level': 'DEBUG',
+            },
+            'file': {
+                'handlers': ['detailed_file_handler'],
+                'level': 'INFO'
             }
         }
     })

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -1,30 +1,61 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 '''
 Usage:
   forklift update
-  forklift update-specific <path>
+  forklift update-specific
 Options:
   --config     the path to some cfg or text file or something where we keep paths to places where there are update plugins.
                defaults to some relative or static path.
   --plugin     the name of the plugin used to filter execution. maybe a partial match or glob or exact match?
 Arguments:
   <path>       an optional path to pass in so you can run a certain directory
-🚜 forklift 🚜
+forklift 🚜
 '''
 
+import logging.config
 import sys
 from docopt import docopt
 
 
 def main():
     arguments = docopt(__doc__, version='1.0.0')
+    _setup_logging()
 
     if arguments['update']:
         pass
     elif arguments['update-specific']:
         pass
+
+
+def _setup_logging():
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'detailed_formatter': {
+                'format': '%(levelname).4s %(asctime)s %(module)s:%(lineno)-4s %(message)s',
+                'datefmt': '%m-%d %H:%M:%S'
+            },
+            'plain_formatter': {
+                'format': '%(message)s'
+            }
+        },
+        'handlers': {
+            'detailed_handler': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                'formatter': 'detailed_formatter',
+                'stream': 'ext://sys.stdout'
+            }
+        },
+        'loggers': {
+            '': {
+                'handlers': ['detailed_handler'],
+                'level': 'DEBUG',
+            }
+        }
+    })
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/forklift/settings.py
+++ b/src/forklift/settings.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''
+settings.py
+-----------------------------------------
+A module for holding generic settings
+'''
+
+#: `console` or `file`
+LOGGER = 'console'


### PR DESCRIPTION
This introduces the python standard logging module.

I've configured two loggers, one to go to a file that and one that will go to the console. The file logger will create a forklift.log file when the script is run and keep that for 24 hours. Once the 24 hours has passed, it will rename that log file to forklift.log.the date. It will keep 7 of those files. 

We may want to change this to hours and do like 23 or something but I think this will do what we want.

We now have a few [logging levels](https://docs.python.org/2/library/logging.html#levels) log.info, warning, error, critical, debug, and exception. this does not handle the gp tool logging like the agrc one but we can rework that.