### PR TITLE
core._check_schema -> core.check_schema

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -26,7 +26,7 @@ def update(crate, validate_crate):
         One of the result string constants from models.Crate
 
     Checks to see if a crate can be updated by using validate_crate (if implemented
-    within the pallet) or _check_schema otherwise. If the crate is valid it
+    within the pallet) or check_schema otherwise. If the crate is valid it
     then updates the data.
     '''
 
@@ -44,7 +44,7 @@ def update(crate, validate_crate):
         try:
             has_custom = validate_crate(crate)
             if has_custom == NotImplemented:
-                _check_schema(crate.source, crate.destination)
+                check_schema(crate.source, crate.destination)
         except ValidationException as e:
             log.warn('validation error: %s for crate %r',
                      e.message,
@@ -124,7 +124,7 @@ def _move_data(crate):
     log.debug('edit session stopped')
 
 
-def _check_schema(source_dataset, destination_dataset):
+def check_schema(source_dataset, destination_dataset):
     '''
     source_dataset: String
     destination_dataset: String

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,7 +63,7 @@ class CoreTests(unittest.TestCase):
     @patch('arcpy.Exists')
     def test_update_default_validation_that_fails(self, arcpy_exists):
         arcpy_exists.return_value = True
-        core._check_schema = Mock(side_effect=ValidationException())
+        core.check_schema = Mock(side_effect=ValidationException())
 
         def custom(crate):
             return NotImplemented
@@ -120,17 +120,17 @@ class CoreTests(unittest.TestCase):
     def test_schema_changes(self):
         arcpy.Copy_management(check_for_changes_gdb, test_gdb)
 
-        result = core._check_schema(path.join(test_gdb, 'ZipCodes'), path.join(check_for_changes_gdb, 'FieldLength'))
+        result = core.check_schema(path.join(test_gdb, 'ZipCodes'), path.join(check_for_changes_gdb, 'FieldLength'))
         self.assertEqual(result, False)
 
-        result = core._check_schema(path.join(test_gdb, 'ZipCodes'), path.join(check_for_changes_gdb, 'ZipCodes'))
+        result = core.check_schema(path.join(test_gdb, 'ZipCodes'), path.join(check_for_changes_gdb, 'ZipCodes'))
         self.assertEqual(result, True)
 
     def test_check_schema_ignore_length_for_all_except_text(self):
         self.check_for_local_sde()
 
         # only worry about length on text fields
-        result = core._check_schema(
+        result = core.check_schema(
             path.join(update_tests_sde, r'UPDATE_TESTS.DBO.Hello\UPDATE_TESTS.DBO.DNROilGasWells'),
             path.join(check_for_changes_gdb, 'DNROilGasWells'))
         self.assertEqual(result, True)
@@ -155,16 +155,16 @@ class CoreTests(unittest.TestCase):
 
     def test_check_schema_match(self):
         self.assertEqual(
-            core._check_schema(
+            core.check_schema(
                 path.join(check_for_changes_gdb, 'FieldLength'), path.join(check_for_changes_gdb, 'FieldLength2')),
             False)
 
         self.assertEqual(
-            core._check_schema(
+            core.check_schema(
                 path.join(check_for_changes_gdb, 'FieldType'), path.join(check_for_changes_gdb, 'FieldType2')), False)
 
         self.assertEqual(
-            core._check_schema(
+            core.check_schema(
                 path.join(check_for_changes_gdb, 'ZipCodes'), path.join(check_for_changes_gdb2, 'ZipCodes')), True)
 
     def test_create_destination_data_feature_class(self):


### PR DESCRIPTION
I want to have access to this from within custom `Pallet.validate_crate` functions so that I can check the schemas and then do custom validation.