### PR TITLE
Tokens

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -57,7 +57,12 @@ class LightSwitch(object):
 
     def _return_false_for_status(self, json_response):
         if 'status' in json_response.keys() and json_response['status'] == 'error':
-            return (False, '; '.join(json_response['messages']))
+            if 'Token Expired.' in json_response['messages']:
+                self._request_token()
+
+                return (True, 'Requested new token')
+            else:
+                return (False, '; '.join(json_response['messages']))
 
         return (True, None)
 

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -65,6 +65,7 @@ class LightSwitch(object):
         data = {'username': username,
                 'password': password,
                 'client': 'requestip',
+                'expiration': 60,
                 'f': 'json'}
 
         response = requests.post(token_url.format(server), data=data)

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -23,7 +23,7 @@ server = secrets.ags_server_host
 class LightSwitch(object):
     def __init__(self):
         self.token = None
-        self.token_expire_date = 0
+        self.token_expire_milliseconds = 0
         self.payload = None
 
     def turn_off(self, service, type):
@@ -41,7 +41,7 @@ class LightSwitch(object):
 
     def _fetch(self, url):
         # check to make sure that token isn't expired
-        if self.token_expire_date <= time() * 1000:
+        if self.token_expire_milliseconds <= time() * 1000:
             self._request_token()
 
         data = {'f': 'json', 'token': self.token}
@@ -74,4 +74,4 @@ class LightSwitch(object):
         self._return_false_for_status(response_data)
 
         self.token = response_data['token']
-        self.token_expire_date = response_data['expires']
+        self.token_expire_milliseconds = int(response_data['expires'])

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -51,7 +51,7 @@ class LightSwitch(object):
 
         ok = self._return_false_for_status(r.json())
 
-        sleep(10.0)
+        sleep(3.0)
 
         return ok
 


### PR DESCRIPTION
For some unknown reason tokens were expiring and not being refreshed. This PR will increase the expiration of tokens to 1 hour, it will also not only rely on the expiration millisecond time check, I wonder if there was a timezone issue there or something, and check the response as well for expired tokens and refresh.