### PR TITLE
Log sent as email attachment

### DIFF
--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -15,8 +15,6 @@ import seat
 import sys
 from colorama import init as colorama_init, Fore
 from messaging import send_email
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 from git import Repo
 from imp import load_source
 from models import Pallet
@@ -131,17 +129,12 @@ def start_lift(file_path=None, pallet_arg=None):
 def _send_report_email(report_object):
     '''Create and send report email
     '''
+    log_file = join(dirname(config.config_location), 'forklift.log')
+
     with open(template, 'r') as template_file:
         email_content = pystache.render(template_file.read(), report_object)
 
-    message = MIMEMultipart()
-    message.attach(MIMEText(email_content, 'html'))
-
-    log_file = join(dirname(config.config_location), 'forklift.log')
-    if isfile(log_file):
-        message.attach(MIMEText(file(log_file).read()))
-
-    send_email(config.get_config_prop('notify'), 'Forklift Report', message)
+    send_email(config.get_config_prop('notify'), 'Forklift Report', email_content, log_file)
 
 
 def git_update():

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -18,7 +18,7 @@ from messaging import send_email
 from git import Repo
 from imp import load_source
 from models import Pallet
-from os.path import abspath, exists, join, splitext, basename, dirname, isfile
+from os.path import abspath, exists, join, splitext, basename, dirname
 from os import walk
 from os import linesep
 from re import compile

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -15,7 +15,6 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from os.path import basename
 from os.path import isfile
-from os.path import join
 from smtplib import SMTP
 
 log = logging.getLogger('forklift')

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -9,15 +9,20 @@ A module that contains a method for sending emails
 import logging
 import secrets
 from config import get_config_prop
+from email import encoders
+from email import generator
+from email.mime.base import MIMEBase
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from os.path import isfile
+from os.path import join
 from smtplib import SMTP
 
 
 log = logging.getLogger('forklift')
 
 
-def send_email(to, subject, body):
+def send_email(to, subject, body, attachment, save_to_file=False):
     '''
     to: string | string[]
     subject: string
@@ -25,7 +30,6 @@ def send_email(to, subject, body):
 
     Send an email.
     '''
-
     if not isinstance(to, basestring):
         to_addresses = ','.join(to)
     else:
@@ -33,7 +37,7 @@ def send_email(to, subject, body):
 
     if isinstance(body, basestring):
         message = MIMEMultipart()
-        message.attach(MIMEText(body))
+        message.attach(MIMEText(body, 'html'))
     else:
         message = body
 
@@ -41,11 +45,26 @@ def send_email(to, subject, body):
     message['From'] = secrets.from_address
     message['To'] = to_addresses
 
-    smtp = SMTP(secrets.smtp_server, secrets.smtp_port)
-    if get_config_prop('sendEmails'):
+    if isfile(attachment):
+        log_file_attachment = MIMEBase('application', 'octet-stream')
+        log_file_attachment.add_header('Content-Disposition', 'attachment; filename="forklift.log"')
+
+        with(open(attachment, 'rb')) as log_file:
+            log_file_attachment.set_payload(log_file.read())
+
+        encoders.encode_base64(log_file_attachment)
+        message.attach(log_file_attachment)
+
+    if save_to_file:
+        from uuid import uuid4
+        with open(join('C:\\Projects\\TestData\\EmailPickup', str(uuid4()) + '.eml'), 'w') as outfile:
+            gen = generator.Generator(outfile)
+            gen.flatten(message)
+    elif get_config_prop('sendEmails'):
+        smtp = SMTP(secrets.smtp_server, secrets.smtp_port)
         smtp.sendmail(secrets.from_address, to, message.as_string())
         smtp.quit()
+
+        return smtp
     else:
         log.info('sendEmails is False. No email sent.')
-
-    return smtp

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -18,17 +18,17 @@ from mock import patch
 class SendEmail(unittest.TestCase):
     def test_to_addresses(self, SMTP_mock, get_config_prop_mock):
         get_config_prop_mock.return_value = True
-        smtp = send_email(['one@utah.gov', 'two@utah.gov'], '', '')
+        smtp = send_email(['one@utah.gov', 'two@utah.gov'], '', '', attachment='None')
 
         self.assertEqual(smtp.sendmail.call_args[0][1], ['one@utah.gov', 'two@utah.gov'])
 
-        smtp = send_email('one@utah.gov', '', '')
+        smtp = send_email('one@utah.gov', '', '', attachment='None')
 
         self.assertEqual(smtp.sendmail.call_args[0][1], 'one@utah.gov')
 
     def test_string_body(self, SMTP_mock, get_config_prop_mock):
         get_config_prop_mock.return_value = True
-        smtp = send_email('hello@utah.gov', 'subject', 'body')
+        smtp = send_email('hello@utah.gov', 'subject', 'body', attachment='None')
 
         self.assertIn('Subject: subject', smtp.sendmail.call_args[0][2])
         self.assertIn('body', smtp.sendmail.call_args[0][2])
@@ -39,13 +39,11 @@ class SendEmail(unittest.TestCase):
         message.attach(MIMEText('<p>test</p>', 'html'))
         message.attach(MIMEText('test'))
 
-        smtp = send_email('hello@utah.gov', 'subject', message)
+        smtp = send_email('hello@utah.gov', 'subject', message, attachment='None')
 
         self.assertIn('test', smtp.sendmail.call_args[0][2])
 
     def test_send_emails_false(self, SMTP_mock, get_config_prop_mock):
         get_config_prop_mock.return_value = False
 
-        smtp = send_email('hello@utah.gov', 'subject', 'body')
-
-        smtp.sendmail.assert_not_called()
+        self.assertIsNone(send_email('hello@utah.gov', 'subject', 'body', attachment='None'))

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,5 @@ deps = flake8
 
 [flake8]
 max-line-length = 160
-max-complexity = 25
+max-complexity = 30
 show-source = True


### PR DESCRIPTION
Attach log file instead of inlining it. 

Do not create SMTP instance if it is not used.

Create local .eml files for testing.