### PR TITLE
reset env between ship

### DIFF
--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -12,6 +12,7 @@ import shutil
 from arcgis import LightSwitch
 from arcpy import Compact_management
 from arcpy import Describe
+from arcpy import env
 from forklift.models import Crate
 from os import makedirs
 from os import path
@@ -106,6 +107,7 @@ def process_pallets(pallets, is_post_copy=False):
                 try:
                     log.info('shipping pallet: %r', pallet)
                     pallet.ship()
+                    env.workspace = None
                     log.debug('shipped pallet %s', seat.format_time(clock() - start_seconds))
                 except Exception as e:
                     pallet.success = (False, e.message)

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -90,6 +90,7 @@ def process_pallets(pallets, is_post_copy=False):
                 start_seconds = clock()
 
                 try:
+                    env.workspace = None
                     if not is_post_copy:
                         pallet.process()
                     else:
@@ -106,8 +107,8 @@ def process_pallets(pallets, is_post_copy=False):
 
                 try:
                     log.info('shipping pallet: %r', pallet)
-                    pallet.ship()
                     env.workspace = None
+                    pallet.ship()
                     log.debug('shipped pallet %s', seat.format_time(clock() - start_seconds))
                 except Exception as e:
                     pallet.success = (False, e.message)

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -116,6 +116,26 @@ class TestLift(unittest.TestCase):
 
         self.assertEqual(pallet.success, (False, 'ship error'))
 
+    def test_process_pallets_resets_arcpy(self):
+        pallet = self.PalletMock()
+        pallet2 = Mock(Pallet)
+
+        import arcpy
+
+        def modify_workspace(value):
+            arcpy.env.workspace = value
+
+        pallet.ship.side_effect = modify_workspace('forklift')
+        pallet.success = (True,)
+
+        self.assertEqual(arcpy.env.workspace, 'forklift')
+
+        pallet2.success = (True,)
+
+        lift.process_pallets([pallet, pallet2])
+
+        self.assertEqual(arcpy.env.workspace, None)
+
     def test_process_pallets_post_copy(self):
         pallet1 = Mock(Pallet)('one')
         pallet1.is_ready_to_ship = Mock(return_value=True)


### PR DESCRIPTION
I struggled to decide if this is a pallet concern but I decided it should end up in forklift since it breaks downstream pallets. I wonder if we need to be more paranoid and reset the workspace after all of the
places pallets could use it?

closes https://github.com/agrc/warehouse/issues/31