### PR TITLE
use our own scratch gdb

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description of Changes
+This pull requests ...
+
+### Test results and coverage
+
+```
+
+```
+
+### Speed test results
+
+```
+
+```

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -286,6 +286,7 @@ def speedtest(pallet_location):
     #: spoof hashes location so there is no caching
     core.garage = speedtest_destination
     core.hash_gdb_path = join(core.garage, core._hash_gdb)
+    core.scratch_gdb_path = join(core.garage, core._scratch_gdb)
 
     #: delete destination and other artifacts form prior runs
     import arcpy
@@ -297,6 +298,8 @@ def speedtest(pallet_location):
 
     if arcpy.Exists(core.hash_gdb_path):
         arcpy.Delete_management(core.hash_gdb_path)
+    if arcpy.Exists(core.scratch_gdb_path):
+        arcpy.Delete_management(core.scratch_gdb_path)
 
     print('{0}{1}Tests ready starting dry run...{0}'.format(Fore.RESET, Fore.MAGENTA))
 
@@ -314,6 +317,8 @@ def speedtest(pallet_location):
         arcpy.Delete_management(join(speedtest_destination, 'DestinationData.gdb'))
     if arcpy.Exists(core.hash_gdb_path):
         arcpy.Delete_management(core.hash_gdb_path)
+    if arcpy.Exists(core.scratch_gdb_path):
+        arcpy.Delete_management(core.scratch_gdb_path)
 
     print('{1}Dry Run Output{0}{2}{3}'.format(Fore.RESET, Fore.CYAN, linesep, dry_report))
     print('{1}Repeat Run Output{0}{2}{3}'.format(Fore.RESET, Fore.CYAN, linesep, repeat_report))

--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -27,7 +27,9 @@ hash_id_field = 'Id'
 garage = path.dirname(config_location)
 
 _hash_gdb = 'hashes.gdb'
+_scratch_gdb = 'scratch.gdb'
 
+scratch_gdb_path = path.join(garage, _scratch_gdb)
 hash_gdb_path = path.join(garage, _hash_gdb)
 
 
@@ -39,12 +41,12 @@ def init():
         log.info('%s does not exist. creating', hash_gdb_path)
         arcpy.CreateFileGDB_management(garage, _hash_gdb)
 
-    #: clear out scratchGDB
-    arcpy.env.workspace = arcpy.env.scratchGDB
-    log.info('clearing out scratchGDB')
-    for featureClass in arcpy.ListFeatureClasses():
-        log.debug('deleting: %s', featureClass)
-        arcpy.Delete_management(featureClass)
+    #: create gdb if needed
+    if arcpy.Exists(scratch_gdb_path):
+        log.info('%s exist. recreating', hash_gdb_path)
+        arcpy.Delete_management(scratch_gdb_path)
+
+    arcpy.CreateFileGDB_management(garage, _scratch_gdb)
 
     arcpy.ClearEnvironment('workspace')
 
@@ -238,7 +240,7 @@ def _hash(crate, hash_path, needs_reproject):
     insert_cursor = None
     if needs_reproject:
         changes.table = arcpy.CreateFeatureclass_management(
-            arcpy.env.scratchGDB,
+            scratch_gdb_path,
             crate.name + reproject_temp_suffix,
             geometry_type=crate.source_describe.shapeType.upper(),
             template=crate.source,

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -309,12 +309,16 @@ class Crate(object):
         return self.source_describe.datasetType.lower() == 'table'
 
     def needs_reproject(self):
+
+        if self.is_table():
+            return False
+
         if self.destination_coordinate_system is None:
             needs_reproject = False
         else:
             needs_reproject = self.destination_coordinate_system.name != self.source_describe.spatialReference.name
 
-        return not self.is_table() and needs_reproject
+        return needs_reproject
 
     def _try_to_find_data_source_by_name(self):
         '''try to find the source name in the source workspace.


### PR DESCRIPTION
## Description of Changes

this mornings failure may have been caused by the staging or hourly
scripts using the scratch gdb at the same time as the prod script. Let's
remove the splinter that is the scratch gdb and keep all of our temp
assets in the garage.

### Test results and coverage

```
Name                     Stmts   Miss     Cover   Missing
---------------------------------------------------------
forklift\arcgis.py          65      3    95.38%   48, 96-98
forklift\cli.py            185     27    85.41%   136, 171-176, 183, 230-233, 287-316
forklift\core.py           224     14    93.75%   131, 167-168, 177, 185, 242-254, 282, 325, 400
forklift\lift.py           127     26    79.53%   44-45, 131-152, 158, 176-177, 213-215, 228-229
forklift\models.py         188      6    96.81%   77, 260, 268, 315, 350-351
---------------------------------------------------------
TOTAL                      878     76    91.34%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
155 tests run in 67.545 seconds.
10 skipped (145 tests passed)
```

### Speed test results

```
Speed Test Results
Dry Run: 1.71 minutes
Repeat: 18659 ms
```