### PR TITLE
Don't define logger in core

### DIFF
--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -86,7 +86,7 @@ def start_lift(file_path=None, pallet_arg=None):
     pallets_to_lift, all_pallets = _sort_pallets(file_path, pallet_arg)
 
     start_process = clock()
-    core.init()
+    core.init(log)
     lift.process_crates_for(pallets_to_lift, core.update, config.get_config_prop('configuration'))
     log.info('process_crates time: %s', seat.format_time(clock() - start_process))
 

--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -7,14 +7,13 @@ Tools for updating the data associated with a models.Crate
 '''
 
 import arcpy
-import logging
 from config import config_location
 from exceptions import ValidationException
 from models import Changes, Crate
 from os import path
 from hashlib import md5
 
-log = logging.getLogger('forklift')
+log = None
 
 reproject_temp_suffix = '_fl'
 
@@ -33,9 +32,15 @@ scratch_gdb_path = path.join(garage, _scratch_gdb)
 hash_gdb_path = path.join(garage, _hash_gdb)
 
 
-def init():
-    '''make sure forklift is ready to run. create the hashing gdb and clear out the scratch geodatabase
+def init(logger):
     '''
+    make sure forklift is ready to run. create the hashing gdb and clear out the scratch geodatabase
+    logger is passed in from cli.py (rather than just setting it via `log = logging.getLogger('forklift')`)
+    to enable other projects to use this module without colliding with the same logger
+    '''
+    global log
+    log = logger
+
     #: create gdb if needed
     if not arcpy.Exists(hash_gdb_path):
         log.info('%s does not exist. creating', hash_gdb_path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ Tests for the core.py module
 import arcpy
 import arcpy_mocks
 import unittest
+from forklift import cli
 from forklift import core
 from forklift.models import Crate
 from forklift.exceptions import ValidationException
@@ -45,7 +46,7 @@ class CoreTests(unittest.TestCase):
         delete_if_arcpy_exists(test_gdb)
         delete_if_arcpy_exists(test_folder)
         delete_if_arcpy_exists(core.hash_gdb_path)
-        core.init()
+        core.init(cli.log)
 
     def tearDown(self):
         delete_if_arcpy_exists(test_gdb)


### PR DESCRIPTION
## Description of Changes
The allows the deq hourly to use core without using the same logger as the rest of forklift. The deq hourly logs now have their own file name (`deqhourly.log`).

### Test results and coverage

```
Name                     Stmts   Miss     Cover   Missing
---------------------------------------------------------
forklift\arcgis.py          65      3    95.38%   48, 96-98
forklift\cli.py            189     32    83.07%   136, 171-176, 183, 230-233, 287-321
forklift\core.py           217      8    96.31%   137, 173-174, 183, 191, 257, 331, 406
forklift\lift.py           127     26    79.53%   44-45, 131-152, 158, 176-177, 213-215, 228-229
forklift\models.py         190      4    97.89%   77, 319, 354-355
---------------------------------------------------------
TOTAL                      877     73    91.68%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
155 tests run in 288.568 seconds (155 tests passed)
```

### Speed test results

```
Speed Test Results
Dry Run: 3.7 minutes
Repeat: 51.23 seconds
```

Closes #136