### PR TITLE
Normalize copy_data paths

### DIFF
--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -237,19 +237,21 @@ def _hydrate_data_structures(specific_pallets, all_pallets):
     data_being_moved = set([])
     destination_to_pallet = {}
 
+    def normalize_workspace(workspace_path):
+        return path.normpath(workspace_path.lower())
+
     #: get the services affected by this pallet
     for pallet in specific_pallets:
         for service in pallet.arcgis_services:
             services_affected.add(service)
 
         for workspace in pallet.copy_data:
-            workspace = workspace.lower()
-            data_being_moved.add(workspace)
+            data_being_moved.add(normalize_workspace(workspace))
 
     #: append the services that share datasources
     for pallet in all_pallets:
         for workspace in pallet.copy_data:
-            workspace = workspace.lower()
+            workspace = normalize_workspace(workspace)
             if workspace not in data_being_moved:
                 continue
 

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -332,18 +332,32 @@ class TestLift(unittest.TestCase):
         pallets = [Pallet(), Pallet(), Pallet()]
 
         pallets[0].requires_processing = Mock(return_value=True)
-        pallets[0].copy_data = ['location']
+        pallets[0].copy_data = ['C:\location']
         pallets[0].arcgis_services = ['service1']
 
-        pallets[1].copy_data = ['Location']
+        pallets[1].copy_data = ['C:\Location']
         pallets[1].arcgis_services = ['service2']
 
-        pallets[2].copy_data = ['location2']
+        pallets[2].copy_data = ['C:\location2']
 
         affected_services, data_being_moved, destination_to_pallet = lift._hydrate_data_structures(pallets[:1], pallets)
         data_being_moved = list(data_being_moved)
 
-        self.assertEqual(data_being_moved[0], 'location')
+        self.assertEqual(data_being_moved[0], 'c:\location')
         self.assertEqual(len(data_being_moved), 1)
-        self.assertEqual(destination_to_pallet['location'], [pallets[0], pallets[1]])
+        self.assertEqual(destination_to_pallet['c:\\location'], [pallets[0], pallets[1]])
+        self.assertEqual(affected_services, set(['service2', 'service1']))
+
+    def test_hydrate_data_structures_normalizes_paths(self):
+        pallets = [Pallet(), Pallet()]
+
+        pallets[0].requires_processing = Mock(return_value=True)
+        pallets[0].copy_data = ['C:\\\\Scheduled\\staging\\political_utm.gdb']
+        pallets[0].arcgis_services = ['service1']
+
+        pallets[1].copy_data = ['C:\\Scheduled\\staging\\political_utm.gdb']
+        pallets[1].arcgis_services = ['service2']
+
+        affected_services, data_being_moved, destination_to_pallet = lift._hydrate_data_structures(pallets[:1], pallets)
+
         self.assertEqual(affected_services, set(['service2', 'service1']))


### PR DESCRIPTION
## Description of Changes
This prevents paths such as `C:\\Scheduled\\staging\\political_utm.gdb` and `C:\\\\Scheduled\\staging\\political_utm.gdb` from being treated a separate workspaces. This was preventing the services from the PoliticalDistricts pallet from being shut down when the data from the Hava pallet was updated even thought they were pointed at the same `copy_data` geodatabase.

### Test results and coverage

```
Name                     Stmts   Miss     Cover   Missing
---------------------------------------------------------
forklift\arcgis.py          65      3    95.38%   48, 96-98
forklift\cli.py            189     32    83.07%   136, 171-176, 183, 230-233, 287-321
forklift\core.py           227      9    96.04%   75, 146, 187-188, 197, 205, 271, 345, 420
forklift\lift.py           128     26    79.69%   44-45, 131-152, 158, 176-177, 213-215, 228-229
forklift\models.py         190      4    97.89%   77, 319, 354-355
---------------------------------------------------------
TOTAL                      888     74    91.67%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
156 tests run in 303.835 seconds (156 tests passed)
```

### Speed test results

```
Speed Test Results
Dry Run: 3.81 minutes
Repeat: 51.58 seconds
```
