### PR TITLE
try resetting workspace cache for compresses

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -203,6 +203,7 @@ def update(crate, validate_crate):
         return (Crate.UNHANDLED_EXCEPTION, e.message)
     finally:
         arcpy.ResetEnvironments()
+        arcpy.ClearWorkspaceCache_management()
 
 
 def _hash(crate, hash_path):

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -12,6 +12,7 @@ import shutil
 from arcpy import Compact_management
 from arcpy import Describe
 from arcgis import LightSwitch
+from arcpy import ClearWorkspaceCache_management as ClearWorkspaceCache
 from arcpy import ResetEnvironments
 from forklift.models import Crate
 from os import makedirs
@@ -91,6 +92,7 @@ def process_pallets(pallets, is_post_copy=False):
 
                 try:
                     ResetEnvironments()
+                    ClearWorkspaceCache()
                     if not is_post_copy:
                         pallet.process()
                     else:
@@ -108,6 +110,7 @@ def process_pallets(pallets, is_post_copy=False):
                 try:
                     log.info('shipping pallet: %r', pallet)
                     ResetEnvironments()
+                    ClearWorkspaceCache()
                     pallet.ship()
                     log.debug('shipped pallet %s', seat.format_time(clock() - start_seconds))
                 except Exception as e:


### PR DESCRIPTION
## Changes

Let's try reseting the [workspace cache](http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/clear-workspace-cache.htm) after each pallet. It's all over http://support.esri.com/technical-article/000011679

refs https://github.com/agrc/warehouse/issues/38

## Test Results and Coverage

```
Name                 Stmts   Miss     Cover   Missing
-----------------------------------------------------
forklift\arcgis.py      65      3    95.38%   48, 96-98
forklift\cli.py        224     64    71.43%   138, 173-178, 185, 232-235, 283-300, 307-318, 328-377
forklift\core.py       233     10    95.71%   84-88, 155, 199, 281, 290, 358, 433
forklift\lift.py       131     26    80.15%   45-46, 134-155, 161, 179-180, 216-218, 231-232
forklift\models.py     168      6    96.43%   75, 257, 265, 317, 352-353
-----------------------------------------------------
TOTAL                  911    109    88.04%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
150 tests run in 125.553 seconds.
11 skipped (139 tests passed)
___________________________________ summary ___________________________________
  unit: commands succeeded
  congratulations :)
```

## Speed Test Results

```
Speed Test Results
Dry Run: 3.3 minutes
Repeat: 69.0 seconds
```