### PR TITLE
add static_data property to pallets and associated cli option

### DIFF
--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -121,7 +121,7 @@ def global_exception_handler(ex_cls, ex, tb):
     last_traceback = (traceback.extract_tb(tb))[-1]
     line_number = last_traceback[1]
     file_name = last_traceback[0].split(".")[0]
-    error = traceback.format_exception(ex_cls, ex, tb)
+    error = '\n'.join(traceback.format_exception(ex_cls, ex, tb))
 
     log.error(('global error handler line: %s (%s)' % (line_number, file_name)))
     log.error(error)

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -48,6 +48,7 @@ from messaging import send_email
 from logging import shutdown
 from os import makedirs
 from os import startfile
+from os import linesep
 from os.path import abspath
 from os.path import dirname
 from os.path import join
@@ -121,7 +122,7 @@ def global_exception_handler(ex_cls, ex, tb):
     last_traceback = (traceback.extract_tb(tb))[-1]
     line_number = last_traceback[1]
     file_name = last_traceback[0].split(".")[0]
-    error = '\n'.join(traceback.format_exception(ex_cls, ex, tb))
+    error = linesep.join(traceback.format_exception(ex_cls, ex, tb))
 
     log.error(('global error handler line: %s (%s)' % (line_number, file_name)))
     log.error(error)

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -5,35 +5,37 @@ forklift 🚜
 
 Usage:
     forklift config init
-    forklift config set --key <key> --value <value>
     forklift config repos --add <repo>
-    forklift config repos --remove <repo>
     forklift config repos --list
+    forklift config repos --remove <repo>
+    forklift config set --key <key> --value <value>
     forklift garage open
-    forklift list-pallets
     forklift git-update
     forklift lift [<file-path>] [--pallet-arg <arg>] [--verbose]
+    forklift list-pallets
     forklift speedtest
+    forklift update-static <file-path>
 
 Arguments:
     repo            The name of a GitHub repository in <owner>/<name> format.
-    file-path       A path to a file that defines a pallet.
-    arg             A string to be used as an optional initialization parameter to the pallet.
+    file-path       A path to a file that defines one or multiple pallets.
+    pallet-arg      A string to be used as an optional initialization parameter to the pallet.
 
 Examples:
     forklift config init                               Creates the config file.
-    forklift config set --key <key> --value <value>    Sets a key in the config with a value.
     forklift config repos --add agrc/ugs-chemistry     Adds a path to the config. Checks for duplicates.
-    forklift config repos --remove agrc/ugs-chemistry  Removes a path from the config.
     forklift config repos --list                       Outputs the list of pallet folder paths in your config file.
+    forklift config repos --remove agrc/ugs-chemistry  Removes a path from the config.
+    forklift config set --key <key> --value <value>    Sets a key in the config with a value.
     forklift garage open                               Opens the garage folder with explorer.
-    forklift list-pallets                              Outputs the list of pallets from the config.
     forklift git-update                                Pulls the latest updates to all git repositories.
     forklift lift                                      The main entry for running all of pallets found in the warehouse folder.
     forklift lift --verbose                            Print DEBUG statements to the console.
     forklift lift path/to/file                         Run a specific pallet.
     forklift lift path/to/file --pallet-arg arg        Run a specific pallet with "arg" as an initialization parameter.
+    forklift list-pallets                              Outputs the list of pallets from the config.
     forklift speedtest                                 Test the speed on a predefined pallet.
+    forklift update-static path/to/file                Updates the static data defined in the specified pallet.
 '''
 
 import config
@@ -62,9 +64,6 @@ def main():
     _setup_logging(args['--verbose'])
     _add_global_error_handler()
 
-    if args['garage'] and args['open']:
-        startfile(dirname(cli.init()))
-
     if args['config']:
         if args['init']:
             message = cli.init()
@@ -86,14 +85,8 @@ def main():
         if args['repos'] and args['--list']:
             for folder in cli.list_repos():
                 print(folder)
-    elif args['list-pallets']:
-        pallets = cli.list_pallets()
-
-        if len(pallets) == 0:
-            print('No pallets found!')
-        else:
-            for plug in pallets:
-                print(': '.join(plug))
+    elif args['garage'] and args['open']:
+        startfile(dirname(cli.init()))
     elif args['git-update']:
         cli.git_update()
     elif args['lift']:
@@ -104,8 +97,18 @@ def main():
                 cli.start_lift(args['<file-path>'])
         else:
             cli.start_lift()
+    elif args['list-pallets']:
+        pallets = cli.list_pallets()
+
+        if len(pallets) == 0:
+            print('No pallets found!')
+        else:
+            for plug in pallets:
+                print(': '.join(plug))
     elif args['speedtest']:
         cli.speedtest(speedtest)
+    elif args['update-static']:
+        cli.update_static(args['<file-path>'])
 
     shutdown()
 

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -22,20 +22,20 @@ Arguments:
     pallet-arg      A string to be used as an optional initialization parameter to the pallet.
 
 Examples:
-    forklift config init                               Creates the config file.
-    forklift config repos --add agrc/ugs-chemistry     Adds a path to the config. Checks for duplicates.
-    forklift config repos --list                       Outputs the list of pallet folder paths in your config file.
-    forklift config repos --remove agrc/ugs-chemistry  Removes a path from the config.
-    forklift config set --key <key> --value <value>    Sets a key in the config with a value.
-    forklift garage open                               Opens the garage folder with explorer.
-    forklift git-update                                Pulls the latest updates to all git repositories.
-    forklift lift                                      The main entry for running all of pallets found in the warehouse folder.
-    forklift lift --verbose                            Print DEBUG statements to the console.
-    forklift lift path/to/file                         Run a specific pallet.
-    forklift lift path/to/file --pallet-arg arg        Run a specific pallet with "arg" as an initialization parameter.
-    forklift list-pallets                              Outputs the list of pallets from the config.
-    forklift speedtest                                 Test the speed on a predefined pallet.
-    forklift update-static path/to/file                Updates the static data defined in the specified pallet.
+    forklift config init                                    Creates the config file.
+    forklift config repos --add agrc/ugs-chemistry          Adds a path to the config. Checks for duplicates.
+    forklift config repos --list                            Outputs the list of pallet folder paths in your config file.
+    forklift config repos --remove agrc/ugs-chemistry       Removes a path from the config.
+    forklift config set --key <key> --value <value>         Sets a key in the config with a value.
+    forklift garage open                                    Opens the garage folder with explorer.
+    forklift git-update                                     Pulls the latest updates to all git repositories.
+    forklift lift                                           The main entry for running all of pallets found in the warehouse folder.
+    forklift lift --verbose                                 Print DEBUG statements to the console.
+    forklift lift path/to/pallet_file.py                    Run a specific pallet.
+    forklift lift path/to/pallet_file.py --pallet-arg arg   Run a specific pallet with "arg" as an initialization parameter.
+    forklift list-pallets                                   Outputs the list of pallets from the config.
+    forklift speedtest                                      Test the speed on a predefined pallet.
+    forklift update-static path/to/pallet_file.py           Updates the static data defined in the specified pallet.
 '''
 
 import config

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -236,10 +236,10 @@ def copy_data(specific_pallets, all_pallets, config_copy_destinations):
             pass
 
     #: no pallets to process. we are done here
-    if len(specific_pallets) == 0:
+    if len(filtered_specific_pallets) == 0:
         return ''
 
-    services_affected, data_being_moved, destination_to_pallet = _hydrate_data_structures(specific_pallets, all_pallets)
+    services_affected, data_being_moved, destination_to_pallet = _hydrate_data_structures(filtered_specific_pallets, all_pallets)
     results = _stop_services(services_affected)
 
     for source in data_being_moved:

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -22,6 +22,7 @@ from os import walk
 from time import clock
 
 log = logging.getLogger('forklift')
+service_msg = 'Service(s) will not {}: {}. '
 
 
 def process_crates_for(pallets, update_def, configuration='Production'):
@@ -113,6 +114,40 @@ def process_pallets(pallets, is_post_copy=False):
             log.error('error %s pallet: %s for pallet: %r', verb, e.message, pallet, exc_info=True)
 
 
+def update_static_for(pallets, config_copy_destinations, force):
+    '''
+    pallets: Pallet[]
+    config_copy_destinations: String[]
+    force: Boolean
+
+    Loop over pallets and check to see if data defined in `static_data` is in `copyDestinations`.
+    If it's not their the data is copied. If it is there and force is True, then the services are
+    shut down and the data is overwritten.
+    '''
+
+    results = ''
+    for pallet in pallets:
+        log.info('checking %s pallet', pallet)
+        for source in pallet.static_data:
+            if not path.exists(source):
+                log.error('static_data: %s does not exist!', source)
+                continue
+
+            destinations = map(lambda d: path.join(d, source.split('\\')[-1]), config_copy_destinations)
+            if all([not path.exists(d) for d in destinations]):
+                log.info('copying static data for the first time')
+                for destination in destinations:
+                    _copy_with_overwrite(source, destination)
+            elif force:
+                log.info('overwriting static data')
+                results = _stop_services(pallet.arcgis_services)
+                for destination in destinations:
+                    _copy_with_overwrite(source, destination)
+                results += ' ' + _start_services(pallet.arcgis_services)
+
+    return results
+
+
 def create_report_object(pallets, elapsed_time, copy_results, git_errors):
     reports = [pallet.get_report() for pallet in pallets]
 
@@ -125,6 +160,7 @@ def create_report_object(pallets, elapsed_time, copy_results, git_errors):
 
 
 def _copy_with_overwrite(source, destination):
+    log.info('copying with overwrite: %s to %s', source, destination)
     for src_dir, dirs, files in walk(source):
         dst_dir = src_dir.replace(source, destination, 1)
 
@@ -149,7 +185,42 @@ def _copy_with_overwrite(source, destination):
                 pass
 
 
+def _stop_services(services):
+    lightswitch = LightSwitch()
+
+    log.info('stopping %s dependent services.', len(services))
+    ok, problem_children = lightswitch.ensure('off', services)
+
+    if not ok:
+        stop_msg = service_msg.format('stop', problem_children) + 'This will affect data copy.'
+        log.error(stop_msg)
+        return stop_msg
+
+    return ''
+
+
+def _start_services(services):
+    lightswitch = LightSwitch()
+
+    log.info('starting %s dependent services.', len(services))
+    ok, problem_children = lightswitch.ensure('on', services)
+
+    if not ok:
+        start_msg = service_msg.format('start', problem_children)
+        log.error(start_msg)
+        return start_msg
+
+    return ''
+
+
 def copy_data(specific_pallets, all_pallets, config_copy_destinations):
+    '''
+    specific_pallets: Pallet[]
+    all_pallets: Pallet[]
+    config_copy_destinations: string[]
+
+    Copies databases from either `copy_data` or `static_data` to `config_copy_destinations`.
+    '''
     #: we're lifting everything
     if len(specific_pallets) == 0:
         specific_pallets = all_pallets
@@ -165,21 +236,11 @@ def copy_data(specific_pallets, all_pallets, config_copy_destinations):
             pass
 
     #: no pallets to process. we are done here
-    if len(filtered_specific_pallets) == 0:
-        return
+    if len(specific_pallets) == 0:
+        return ''
 
-    lightswitch = LightSwitch()
-    services_affected, data_being_moved, destination_to_pallet = _hydrate_data_structures(filtered_specific_pallets, all_pallets)
-    results = ''
-
-    log.info('stopping %s dependent services.', len(services_affected))
-    ok, problem_children = lightswitch.ensure('off', services_affected)
-
-    service_msg = 'Service(s) will not {}: {}. '
-    if not ok:
-        stop_msg = service_msg.format('stop', problem_children) + 'This will affect data copy.'
-        results = stop_msg
-        log.error(stop_msg)
+    services_affected, data_being_moved, destination_to_pallet = _hydrate_data_structures(specific_pallets, all_pallets)
+    results = _stop_services(services_affected)
 
     for source in data_being_moved:
         if Describe(source).workspaceFactoryProgID.startswith('esriDataSourcesGDB.FileGDBWorkspaceFactory'):
@@ -209,7 +270,7 @@ def copy_data(specific_pallets, all_pallets, config_copy_destinations):
                     #: There is still a lock?
                     #: The service probably wasn't shut down
                     #: if there was a problem and the temp gdb exists
-                    #: since we couln't delete it before we probably can't delete it now
+                    #: since we couldn't delete it before we probably can't delete it now
                     #: so take what is in x and copy it over what it can in the original
                     #: that _should_ leave the gdb in a functioning state
                     if path.exists(destination_workspace) and path.exists(destination_workspace + 'x'):
@@ -225,13 +286,7 @@ def copy_data(specific_pallets, all_pallets, config_copy_destinations):
 
                 log.error('there was an error copying %s to %s', source, destination_workspace, exc_info=True)
 
-    log.info('starting %s dependent services.', len(services_affected))
-    ok, problem_children = lightswitch.ensure('on', services_affected)
-
-    if not ok:
-        start_msg = service_msg.format('start', problem_children)
-        results += ' ' + start_msg
-        log.error(start_msg)
+    results += _start_services(services_affected)
 
     return results
 

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -55,6 +55,12 @@ class Pallet(object):
         #: the default location to stage geodatabases. For use when creating crates
         self.staging_rack = config.get_config_prop('stagingDestination')
         self.send_email = send_email
+        #: a list of databases or folders that are static and do not participate in crates
+        #: When `forklift lift` is run, it checks for the existence of this data in config.copyDestinations and
+        #: copies the data there if it does not already exists.
+        #: When `forklift update_static <pallet>` is run it copies/overwrites the data in
+        #: copyDestinations (while stopping services in `arcgis_services`).
+        self.static_data = []
 
     def build(self, configuration='Production'):
         '''Invoked before process and ship. Any logic that could cause a pallet to error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # * coding: utf8 *
 '''
-test_lift.py
+test_cli.py
 
 A module that contains tests for the cli.py module
 '''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,3 +257,26 @@ class TestReport(unittest.TestCase):
                   'copy_results': []}
 
         print(cli._format_dictionary(report))
+
+
+class TestUpdateStatic(unittest.TestCase):
+
+    def setUp(self):
+        if exists(config_location):
+            remove(config_location)
+
+    def tearDown(self):
+        if exists(config_location):
+            remove(config_location)
+
+    def test_no_copy_destinations(self):
+        config.set_config_prop('copyDestinations', [])
+        report = cli.update_static(join(test_pallets_folder, 'single_pallet.py'))
+
+        self.assertEquals(report, '')
+
+    def test_copy(self):
+        config.set_config_prop('copyDestinations', ['one', 'two'])
+        report = cli.update_static(join(test_pallets_folder, 'single_pallet.py'))
+
+        self.assertRegexpMatches(report, 'ran successfully')

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -361,3 +361,38 @@ class TestLift(unittest.TestCase):
         affected_services, data_being_moved, destination_to_pallet = lift._hydrate_data_structures(pallets[:1], pallets)
 
         self.assertEqual(affected_services, set(['service2', 'service1']))
+
+
+@patch('forklift.lift._copy_with_overwrite')
+@patch('forklift.lift._start_services')
+@patch('forklift.lift._stop_services')
+class UpdateStaticFor(unittest.TestCase):
+
+    def test_no_existing_data(self, _stop_services_mock, _start_services_mock, _copy_with_overwrite_mock):
+        pallet = Pallet()
+        pallet.static_data = [check_for_changes_gdb]
+
+        lift.update_static_for([pallet], ['blah'], True)
+
+        _stop_services_mock.assert_not_called()
+        _start_services_mock.assert_not_called()
+        _copy_with_overwrite_mock.assert_called_once_with(check_for_changes_gdb, path.join('blah', 'checkForChanges.gdb'))
+
+    def test_existing_data_should_stop_services(self, _stop_services_mock, _start_services_mock, _copy_with_overwrite_mock):
+        pallet = Pallet()
+        pallet.static_data = [check_for_changes_gdb]
+
+        lift.update_static_for([pallet], [path.join(current_folder, 'data')], True)
+
+        _stop_services_mock.assert_called_once()
+        _start_services_mock.assert_called_once()
+
+    def test_no_force_existing_data_does_not_copy(self, _stop_services_mock, _start_services_mock, _copy_with_overwrite_mock):
+        pallet = Pallet()
+        pallet.static_data = [check_for_changes_gdb]
+
+        lift.update_static_for([pallet], [path.join(current_folder, 'data')], False)
+
+        _stop_services_mock.assert_not_called()
+        _start_services_mock.assert_not_called()
+        _copy_with_overwrite_mock.assert_not_called()


### PR DESCRIPTION
## Description of Changes
Add `static_data String[]` property to the `Pallet` class.
Add `update_static <file-path>` command for updating the static data for a specific pallet.
Add check for static data in `lift` command.

Unrelated: Fix global error handler so that it actually emails us.

Ref: #131

### Test results and coverage

```
Name                     Stmts   Miss     Cover   Missing
---------------------------------------------------------
forklift\arcgis.py          65      3    95.38%   48, 96-98
forklift\cli.py            242     78    67.77%   109-110, 181-186, 193, 240-243, 291-308, 315-326, 336-385, 395-415
forklift\core.py           244      9    96.31%   84-88, 155, 196, 204, 363, 438
forklift\lift.py           152     40    73.68%   46-47, 133-153, 169-190, 200-202, 214-216, 231, 276-278
forklift\models.py         171      4    97.66%   85, 328, 363-364
---------------------------------------------------------
TOTAL                      965    134    86.11%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
151 tests run in 466.739 seconds (151 tests passed)

lint: commands succeeded
congratulations :)
```

### Speed test results

```
Dry Run: 5.32 minutes
Repeat: 1.56 minutes
```
