### PR TITLE
implement scorched-earth command

### DIFF
--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -13,6 +13,7 @@ Usage:
     forklift git-update
     forklift lift [<file-path>] [--pallet-arg <arg>] [--verbose]
     forklift list-pallets
+    forklift scorched-earth
     forklift speedtest
     forklift update-static <file-path>
 
@@ -34,6 +35,8 @@ Examples:
     forklift lift path/to/pallet_file.py                    Run a specific pallet.
     forklift lift path/to/pallet_file.py --pallet-arg arg   Run a specific pallet with "arg" as an initialization parameter.
     forklift list-pallets                                   Outputs the list of pallets from the config.
+    forklift scorched-earth                                 WARNING!!! Deletes all data in `config.stagingDestination` as well as the
+                                                            `hashes.gdb` & `scratch.gdb` file geodatabases.
     forklift speedtest                                      Test the speed on a predefined pallet.
     forklift update-static path/to/pallet_file.py           Updates the static data defined in the specified pallet.
 '''
@@ -106,6 +109,8 @@ def main():
         else:
             for plug in pallets:
                 print(': '.join(plug))
+    elif args['scorched-earth']:
+        cli.scorched_earth()
     elif args['speedtest']:
         cli.speedtest(speedtest)
     elif args['update-static']:

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -21,8 +21,10 @@ from models import Pallet
 from os.path import abspath, basename, dirname, exists, join, splitext, realpath
 from os import walk
 from os import linesep
+from os import mkdir
 from re import compile
 from requests import get
+from shutil import rmtree
 from time import clock
 
 log = logging.getLogger('forklift')
@@ -413,3 +415,14 @@ def update_static(file_path):
     log.info('%s', report)
 
     return report
+
+
+def scorched_earth():
+    staging = config.get_config_prop('stagingDestination')
+    for folder in [staging, core.hash_gdb_path, core.scratch_gdb_path]:
+        if exists(folder):
+            log.info('deleting: %s', folder)
+            rmtree(folder)
+
+    log.info('recreating: %s', staging)
+    mkdir(staging)

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -21,7 +21,7 @@ from models import Pallet
 from os.path import abspath, basename, dirname, exists, join, splitext, realpath
 from os import walk
 from os import linesep
-from os import mkdir
+from os import makedirs
 from re import compile
 from requests import get
 from shutil import rmtree
@@ -425,4 +425,4 @@ def scorched_earth():
             rmtree(folder)
 
     log.info('recreating: %s', staging)
-    mkdir(staging)
+    makedirs(staging)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,11 +7,11 @@ A module that contains tests for the cli.py module
 '''
 
 import unittest
-from forklift import cli, config
+from forklift import cli, config, core
 from forklift.models import Crate
 from json import loads
 from mock import patch, Mock
-from os import remove
+from os import remove, mkdir
 from os.path import abspath, dirname, join, exists
 
 test_data_folder = join(dirname(abspath(__file__)), 'data')
@@ -280,3 +280,23 @@ class TestUpdateStatic(unittest.TestCase):
         report = cli.update_static(join(test_pallets_folder, 'single_pallet.py'))
 
         self.assertRegexpMatches(report, 'ran successfully')
+
+
+class TestScorchedEarth(unittest.TestCase):
+    hash_patch = join(test_data_folder, 'hashes.gdb')
+    scratch_patch = join(test_data_folder, 'scratch.gdb')
+
+    @patch('forklift.core.hash_gdb_path', hash_patch)
+    @patch('forklift.core.scratch_gdb_path', scratch_patch)
+    def test_deletes_folders(self):
+        test_staging = join(test_data_folder, 'staging')
+        test_folder = join(test_staging, 'test')
+        mkdir(test_folder)
+        config.set_config_prop('stagingDestination', test_staging)
+
+        cli.scorched_earth()
+
+        self.assertFalse(exists(core.hash_gdb_path))
+        self.assertFalse(exists(core.scratch_gdb_path))
+        self.assertFalse(exists(test_folder))
+        self.assertTrue(exists(test_staging))


### PR DESCRIPTION
## Description of Changes
This pull requests adds a new cli command: `scorched-earth`. It deletes the scratch and hashes GDBs and everything in the staging folder.

### Test results and coverage

```

```

### Speed test results

```

```
