### PR TITLE
Call build on all pallets when a single one is lifted

### DIFF
--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -142,6 +142,14 @@ def _sort_pallets(file_path, pallet_arg):
             else:
                 pallet = PalletClass()
 
+            try:
+                log.debug('building pallet: %r', pallet)
+                pallet.build(config.get_config_prop('configuration'))
+            except Exception as e:
+                pallet.success = (False, e)
+                log.error('error building pallet: %s for pallet: %r', e, pallet, exc_info=True)
+                continue
+
             all_pallets.append(pallet)
             if pallet_location == file_path or file_path is None:
                 sorted_pallets.append(pallet)

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -38,14 +38,6 @@ def process_crates_for(pallets, update_def, configuration='Production'):
     for pallet in pallets:
         log.info('processing crates for pallet: %r', pallet)
 
-        try:
-            log.debug('building pallet: %r', pallet)
-            pallet.build(configuration)
-        except Exception as e:
-            pallet.success = (False, e)
-            log.error('error building pallet: %s for pallet: %r', e, pallet, exc_info=True)
-            continue
-
         for crate in pallet.get_crates():
             log.info('crate: %s', crate.destination_name)
             if crate.result[0] == Crate.INVALID_DATA:


### PR DESCRIPTION
Fixes #186

## Description of Changes
This pull request makes sure that `pallet.build(config)` gets called for all pallets in the config rather than just the one getting lifted.

This will make testing individual pallets easier.

### Test results and coverage

```
Name                    Stmts   Miss     Cover   Missing
--------------------------------------------------------
forklift\arcgis.py         65      3    95.38%   48, 96-98
forklift\cli.py           242     54    77.69%   111-112, 148-149, 156, 191-196, 203, 301-312, 316-325, 335-376
forklift\core.py          174      3    98.28%   119, 139, 322
forklift\lift.py          156     24    84.62%   155-175, 185-187, 199-201, 216, 224-226, 260, 275
forklift\messaging.py      33      1    96.97%   39
forklift\models.py        172      4    97.67%   86, 319, 362-363
--------------------------------------------------------
TOTAL                     900     89    90.11%

4 files skipped due to complete coverage.
-----------------------------------------------------------------------------
154 tests run in 352.078 seconds (154 tests passed)

lint: commands succeeded
congratulations :)
```

### Speed test results

```
Dry Run: 2.85 minutes
Repeat: 2.25 minutes
```
