### PR TITLE
Ignore *.lock files when copying to `copy_data`

### DIFF
--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -251,7 +251,7 @@ def copy_data(specific_pallets, all_pallets, config_copy_destinations):
                     shutil.move(destination_workspace, destination_workspace + 'x')
 
                 log.debug('copying source to destination')
-                shutil.copytree(source, destination_workspace)
+                shutil.copytree(source, destination_workspace, ignore=shutil.ignore_patterns('*.lock'))
 
                 _scrub_hash_fields(destination_workspace)
 


### PR DESCRIPTION
## Description of Changes
This pull request adds an ignore to the copy to `copy_data` that ignores `*.lock` files. This is helpful for pallets that use `MakeFeatureLayer` and leave schema locks on files.

### Test results and coverage

```
Name                    Stmts   Miss     Cover   Missing
--------------------------------------------------------
forklift\arcgis.py         65      3    95.38%   48, 96-98
forklift\cli.py           242     54    77.69%   111-112, 148-149, 156, 191-196, 203, 301-312, 316-325, 335-376
forklift\core.py          174      3    98.28%   119, 139, 322
forklift\lift.py          156     24    84.62%   155-175, 185-187, 199-201, 216, 224-226, 260, 275
forklift\messaging.py      33      1    96.97%   39
forklift\models.py        172      4    97.67%   86, 319, 362-363
--------------------------------------------------------
TOTAL                     900     89    90.11%

4 files skipped due to complete coverage.
-----------------------------------------------------------------------------
154 tests run in 443.176 seconds (154 tests passed)

lint: commands succeeded
congratulations :)
```

### Speed test results

```
Dry Run: 3.74 minutes
Repeat: 2.42 minutes
```
