### PR TITLE
remove deletion of scratch gdb from the end of the process

### DIFF
--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -119,8 +119,6 @@ def start_lift(file_path=None, pallet_arg=None):
 
     log.info('Finished in {}.'.format(elapsed_time))
 
-    core.optimize_internal_gdbs()
-
     report = _format_dictionary(report_object)
     log.info('%s', report)
 

--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -49,12 +49,6 @@ def init(logger):
     arcpy.ClearEnvironment('workspace')
 
 
-def optimize_internal_gdbs():
-    if arcpy.Exists(scratch_gdb_path):
-        log.info('%s deleting', scratch_gdb_path)
-        arcpy.Delete_management(scratch_gdb_path)
-
-
 def update(crate, validate_crate):
     '''
     crate: models.Crate


### PR DESCRIPTION
Pro is throwing Oracle lock errors when we try to delete this database. Since it's deleted at the beginning of the process, we can just drop this method.