### PR TITLE
allow updating of LightSwitch credentials

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 160
+max-complexity = 30
+show-source = True
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -22,19 +22,33 @@ services_url = r'{}services'.format(base_url)
 
 class LightSwitch(object):
     def __init__(self):
+        self.reset_credentials()
+        self._reset_token()
+
+    def set_credentials(self, username, password, host):
+        '''updates the credentials that LightSwitch will use to stop and start services
+        '''
+        if username:
+            self.username = username
+        if password:
+            self.password = password
+        if host:
+            self.server = host
+
+        self._reset_token()
+
+    def reset_credentials(self):
+        '''reset the credentials to the environmental settings
+        '''
         self.username = environ.get('FORKLIFT_AGS_USERNAME')
         self.password = environ.get('FORKLIFT_AGS_PASSWORD')
         self.server = environ.get('FORKLIFT_AGS_SERVER_HOST')
-        self.token = None
-        self.token_expire_milliseconds = 0
-        self.payload = None
 
     def ensure(self, what, affected_services):
-        '''
-        ensures that affected_services are started or stopped with 5 attempts. 
-        what: string 'off' or 'on' 
+        '''ensures that affected_services are started or stopped with 5 attempts.
+        what: string 'off' or 'on'
         affected_services: list { service_name, service_type }
-        
+
         returns the services that still did not do what was requested'''
         tries = 4
         wait = [8, 5, 3, 2, 1]
@@ -122,3 +136,8 @@ class LightSwitch(object):
 
         self.token = response_data['token']
         self.token_expire_milliseconds = int(response_data['expires'])
+
+    def _reset_token(self):
+        self.token = None
+        self.token_expire_milliseconds = 0
+        self.payload = None

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -35,6 +35,9 @@ class LightSwitch(object):
         if host:
             self.server = host
 
+        if not username and not password and not host:
+            raise Exception('Setting all credentials to empty values will use the default env values.')
+
         self._reset_token()
 
     def reset_credentials(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from forklift import cli, config, core
 from forklift.models import Crate
 from json import loads
 from mock import patch, Mock
-from os import remove, mkdir
+from os import remove, makedirs
 from os.path import abspath, dirname, join, exists
 
 test_data_folder = join(dirname(abspath(__file__)), 'data')
@@ -295,7 +295,7 @@ class TestScorchedEarth(unittest.TestCase):
     def test_deletes_folders(self):
         test_staging = join(test_data_folder, 'staging')
         test_folder = join(test_staging, 'test')
-        mkdir(test_folder)
+        makedirs(test_folder)
         config.set_config_prop('stagingDestination', test_staging)
 
         cli.scorched_earth()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,6 +48,7 @@ class CoreTests(unittest.TestCase):
         delete_if_arcpy_exists(test_gdb)
         delete_if_arcpy_exists(test_folder)
         delete_if_arcpy_exists(duplicates_gdb_copy)
+        cli.init()
         core.init(cli.log)
 
     def tearDown(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ basepython = C:\Program Files\ArcGIS\Pro\bin\Python\Scripts\propy.bat
 usedevelop = True
 sitepackages = True
 deps =
-    nose
     nose-cov
     rednose
     mock
@@ -19,7 +18,6 @@ commands =
 usedevelop = False
 sitepackages = True
 deps =
-    nose
     nose-cov
     rednose
     mock


### PR DESCRIPTION
This allows LightSwitch code to be reused on more than the server configured in the environmental variables. 

```
Name                 Stmts   Miss     Cover   Missing
-----------------------------------------------------
forklift\arcgis.py      79     12    84.81%   31-41, 71, 119-121
forklift\cli.py        241     54    77.59%   111-112, 153, 188-193, 200, 247-250, 298-309, 313-322, 332-373
forklift\core.py       172      3    98.26%   119, 139, 322
forklift\lift.py       156     24    84.62%   155-175, 185-187, 199-201, 216, 224-226, 260, 275
forklift\models.py     172      8    95.35%   86, 268-271, 319, 362-363
-----------------------------------------------------
TOTAL                  911    101    88.91%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
155 tests run in 370.170 seconds.
10 skipped (145 tests passed)
```