### PR TITLE
Report Improvements Including Warnings

### DIFF
--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -107,6 +107,7 @@ def start_lift(file_path=None, pallet_arg=None):
 
     if len(copy_destinations) == 0:
         log.info('No `copyDestinations` defined in the config. Skipping update_static...')
+        static_copy_results = ''
     else:
         start_static = clock()
         static_copy_results = lift.update_static_for(pallets_to_lift, copy_destinations, False)
@@ -281,18 +282,22 @@ def _format_dictionary(pallet_reports):
         if not report['success']:
             color = Fore.RED
 
-        report_str += '{}{}{}{}'.format(color, report['name'], Fore.RESET, linesep)
+        report_str += '{3}{0}{1}{2}{3}'.format(color, report['name'], Fore.RESET, linesep)
 
         if report['message']:
-            report_str += 'pallet message: {}{}{}{}'.format(Fore.YELLOW, report['message'], Fore.RESET, linesep)
+            report_str += 'pallet message: {}{}{}{}'.format(Fore.RED, report['message'], Fore.RESET, linesep)
 
         for crate in report['crates']:
-            report_str += '{0:>40}{3} - {1}{4}{2}'.format(crate['name'], crate['result'], linesep, Fore.CYAN, Fore.RESET)
+            report_str += '{0:>40} - {1}{3}{2}'.format(crate['name'], crate['result'], linesep, Fore.RESET)
 
             if crate['crate_message'] is None:
                 continue
 
-            report_str += 'crate message: {0}{1}{2}{3}'.format(Fore.MAGENTA, crate['crate_message'], Fore.RESET, linesep)
+            if crate['message_level'] == 'warning':
+                color = Fore.YELLOW
+            else:
+                color = Fore.RED
+            report_str += 'crate message: {0}{1}{2}{3}'.format(color, crate['crate_message'], Fore.RESET, linesep)
 
     return report_str
 

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -109,11 +109,11 @@ def start_lift(file_path=None, pallet_arg=None):
         log.info('No `copyDestinations` defined in the config. Skipping update_static...')
     else:
         start_static = clock()
-        copy_results += ' ' + lift.update_static_for(pallets_to_lift, copy_destinations, False)
+        static_copy_results = lift.update_static_for(pallets_to_lift, copy_destinations, False)
         log.info('static copy time: %s', seat.format_time(clock() - start_static))
 
     elapsed_time = seat.format_time(clock() - start_seconds)
-    report_object = lift.create_report_object(pallets_to_lift, elapsed_time, copy_results, git_errors)
+    report_object = lift.create_report_object(pallets_to_lift, elapsed_time, copy_results, git_errors, static_copy_results)
 
     _send_report_email(report_object)
 
@@ -269,6 +269,9 @@ def _format_dictionary(pallet_reports):
     if pallet_reports['copy_results'] not in [None, '']:
         report_str += '{}{}{}{}'.format(Fore.RED, pallet_reports['copy_results'], Fore.RESET, linesep)
 
+    if pallet_reports['static_copy_results'] not in [None, '']:
+        report_str += '{}{}{}{}'.format(Fore.RED, pallet_reports['static_copy_results'], Fore.RESET, linesep)
+
     if len(pallet_reports['git_errors']) > 0:
         for git_error in pallet_reports['git_errors']:
             report_str += '{}{}{}'.format(Fore.RED, git_error, linesep)
@@ -393,10 +396,10 @@ def update_static(file_path):
         log.error('No `copyDestinations` defined in the config!')
         return ''
 
-    copy_results = lift.update_static_for(pallets, copy_destinations, True)
+    static_copy_results = lift.update_static_for(pallets, copy_destinations, True)
 
     elapsed_time = seat.format_time(clock() - start_seconds)
-    report_object = lift.create_report_object(pallets, elapsed_time, copy_results, git_errors)
+    report_object = lift.create_report_object(pallets, elapsed_time, '', git_errors, static_copy_results)
     report = _format_dictionary(report_object)
     log.info('%s', report)
 

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -138,7 +138,7 @@ def update_static_for(pallets, config_copy_destinations, force):
     return results
 
 
-def create_report_object(pallets, elapsed_time, copy_results, git_errors):
+def create_report_object(pallets, elapsed_time, copy_results, git_errors, static_copy_results):
     reports = [pallet.get_report() for pallet in pallets]
 
     return {'total_pallets': len(reports),
@@ -146,7 +146,8 @@ def create_report_object(pallets, elapsed_time, copy_results, git_errors):
             'git_errors': git_errors,
             'pallets': reports,
             'total_time': elapsed_time,
-            'copy_results': copy_results}
+            'copy_results': copy_results,
+            'static_copy_results': static_copy_results}
 
 
 def _copy_with_overwrite(source, destination):

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -298,10 +298,23 @@ class Crate(object):
     def get_report(self):
         '''Returns the relavant info related to this crate that is shown on the report as a dictionary
         '''
-        if self.result[0] == self.NO_CHANGES:
+        status = self.result[0]
+        if status == self.NO_CHANGES:
             return None
 
-        return {'name': self.destination_name, 'result': self.result[0], 'crate_message': self.result[1] or ''}
+        if status in [self.WARNING, self.UNINITIALIZED]:
+            message_level = 'warning'
+        elif status in [self.UNHANDLED_EXCEPTION, self.INVALID_DATA]:
+            message_level = 'error'
+        else:
+            message_level = ''
+
+        return {
+            'name': self.destination_name,
+            'result': self.result[0],
+            'crate_message': self.result[1] or '',
+            'message_level': message_level
+        }
 
     def is_table(self):
         '''returns True if the crate defines a table

--- a/src/forklift/report_template.html
+++ b/src/forklift/report_template.html
@@ -7,6 +7,9 @@
         {{#copy_results}}
         <tr><td colspan='2' style='background-color: #fc7973'>{{copy_results}}</td></tr>
         {{/copy_results}}
+        {{#static_copy_results}}
+        <tr><td colspan='2' style='background-color: #fc7973'>{{static_copy_results}}</td></tr>
+        {{/static_copy_results}}
         {{#pallets}}
             <tr>
                 <td colspan='2' style='background-color: {{#success}}#83ec8f{{/success}}

--- a/src/forklift/report_template.html
+++ b/src/forklift/report_template.html
@@ -1,23 +1,37 @@
+<!-- gmail will strip the <style> tag if it's not in the <head> -->
+<head>
+  <style>
+    .error {
+      background-color: #fc7973;
+    }
+    .success {
+      background-color: #83ec8f;
+    }
+    .warning {
+      background-color: #fcc573;
+    }
+  </style>
+</head>
 <p><b>{{num_success_pallets}}</b> out of <b>{{total_pallets}}</b> pallets ran successfully in {{total_time}}.</p>
 <table>
   <tbody>
     {{#git_errors}}
     <tr>
-      <td colspan="2" style="background-color: #fc7973">{{.}}</td>
+      <td colspan="2" class="error">{{.}}</td>
     </tr>
     {{/git_errors}} {{#copy_results}}
     <tr>
-      <td colspan="2" style="background-color: #fc7973">{{copy_results}}</td>
+      <td colspan="2" class="error">{{copy_results}}</td>
     </tr>
     {{/copy_results}} {{#static_copy_results}}
     <tr>
-      <td colspan="2" style="background-color: #fc7973">{{static_copy_results}}</td>
+      <td colspan="2" class="error">{{static_copy_results}}</td>
     </tr>
     {{/static_copy_results}}
 
     {{#pallets}}
     <tr>
-      <td colspan="2" style="background-color: {{#success}}#83ec8f{{/success}} {{^success}}#fc7973{{/success}}">
+      <td colspan="2" class="{{#success}}success{{/success}}{{^success}}error{{/success}}">
         {{name}}
       </td>
     </tr>
@@ -32,7 +46,7 @@
     </tr>
     {{#crate_message}}
     <tr>
-      <td colspan="2" style="padding-left: 20px"><b>{{crate_message}}</b></td>
+      <td colspan="2" class="{{message_level}}" style="padding-left: 20px;"><b>{{crate_message}}</b></td>
     </tr>
     {{/crate_message}}
     {{/crates}}

--- a/src/forklift/report_template.html
+++ b/src/forklift/report_template.html
@@ -1,37 +1,45 @@
 <p><b>{{num_success_pallets}}</b> out of <b>{{total_pallets}}</b> pallets ran successfully in {{total_time}}.</p>
 <table>
-    <tbody>
-        {{#git_errors}}
-        <tr><td colspan='2' style='background-color: #fc7973'>{{.}}</td></tr>
-        {{/git_errors}}
-        {{#copy_results}}
-        <tr><td colspan='2' style='background-color: #fc7973'>{{copy_results}}</td></tr>
-        {{/copy_results}}
-        {{#static_copy_results}}
-        <tr><td colspan='2' style='background-color: #fc7973'>{{static_copy_results}}</td></tr>
-        {{/static_copy_results}}
-        {{#pallets}}
-            <tr>
-                <td colspan='2' style='background-color: {{#success}}#83ec8f{{/success}}
-                    {{^success}}#fc7973{{/success}}'>
-                    {{name}}
-                </td>
-            </tr>
-            <tr>
-                <td colspan='2'><b>{{message}}</b></td>
-            </tr>
-            {{#crates}}
-            <tr>
-                <td style='padding-left: 10px'>{{name}}</td>
-                <td>{{result}}</td>
-            </tr>
-            {{#crate_message}}
-            <tr>
-                <td colspan='2' style='padding-left: 20px'><b>{{crate_message}}</b></td>
-            </tr>
-            {{/crate_message}}
-            {{/crates}}
-            <tr><td></td></tr>
-        {{/pallets}}
-    </tbody>
+  <tbody>
+    {{#git_errors}}
+    <tr>
+      <td colspan="2" style="background-color: #fc7973">{{.}}</td>
+    </tr>
+    {{/git_errors}} {{#copy_results}}
+    <tr>
+      <td colspan="2" style="background-color: #fc7973">{{copy_results}}</td>
+    </tr>
+    {{/copy_results}} {{#static_copy_results}}
+    <tr>
+      <td colspan="2" style="background-color: #fc7973">{{static_copy_results}}</td>
+    </tr>
+    {{/static_copy_results}}
+
+    {{#pallets}}
+    <tr>
+      <td colspan="2" style="background-color: {{#success}}#83ec8f{{/success}} {{^success}}#fc7973{{/success}}">
+        {{name}}
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2"><b>{{message}}</b></td>
+    </tr>
+
+    {{#crates}}
+    <tr>
+      <td style="padding-left: 10px">{{name}}</td>
+      <td>{{result}}</td>
+    </tr>
+    {{#crate_message}}
+    <tr>
+      <td colspan="2" style="padding-left: 20px"><b>{{crate_message}}</b></td>
+    </tr>
+    {{/crate_message}}
+    {{/crates}}
+
+    <tr>
+      <td></td>
+    </tr>
+    {{/pallets}}
+  </tbody>
 </table>

--- a/tests/ReportTests.html
+++ b/tests/ReportTests.html
@@ -1,28 +1,46 @@
+<!DOCTYPE html>
 <html>
+
 <head>
-    <title>Report Template Tests</title>
-    <script src='//cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.js'></script>
-    <script src="//ajax.googleapis.com/ajax/libs/dojo/1.10.4/dojo/dojo.js"></script>
+  <title>Report Template Tests</title>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/dojo/1.10.4/dojo/dojo.js"></script>
+  <style>
+    .container {
+      border: solid 1px gray;
+      padding: 5px;
+    }
+    table {
+      width: 100%;
+    }
+  </style>
 </head>
+
 <body>
-    <h1>Report Template Tests</h1>
+  <h1>Report Template Tests</h1>
 
-    <script type='text/javascript'>
-        require([
-            'dojo/dom-construct',
+  <script type="text/javascript">
+    require([
+      'dojo/dom-construct',
 
-            'dojo/text!./data/report.json',
-            'dojo/text!../src/forklift/report_template.html'
-        ], function (
-            domConstruct,
+      'dojo/text!./data/report_with_errors.json',
+      'dojo/text!./data/report_success.json',
+      'dojo/text!../src/forklift/report_template.html'
+    ], function(
+      domConstruct,
 
-            testJson,
-            reportTemplate
-        ) {
-            var dom = Mustache.render(reportTemplate, JSON.parse(testJson));
-            domConstruct.place(dom, document.body);
-            console.debug(dom);
-        });
-    </script>
+      testJsonErrors,
+      testJsonSuccess,
+      reportTemplate
+    ) {
+      [testJsonErrors, testJsonSuccess].forEach(json => {
+        var container = domConstruct.create('div', {className: 'container'}, document.body);
+        var dom = Mustache.render(reportTemplate, JSON.parse(json));
+        domConstruct.place(dom, container);
+        console.debug(dom);
+      });
+    });
+  </script>
 </body>
+
 </html>

--- a/tests/data/report_success.json
+++ b/tests/data/report_success.json
@@ -1,0 +1,38 @@
+{
+    "num_success_pallets": 3,
+    "total_pallets": 3,
+    "copy_results": "",
+    "static_copy_results": "",
+    "total_time": "4.5 hours",
+    "git_errors": [],
+    "pallets": [
+        {
+            "name": "Z:\\forklift\\samples\\PalletSamples.py:StringCratePallet",
+            "success": true,
+            "message": null,
+            "crates": [{
+                "name": "FeatureClassOne",
+                "result": "Created table successfully."
+            }, {
+                "name": "FeatureClassTwo",
+                "result": "Created table successfully."
+            }]
+        }, {
+            "name": "Z:\\forklift\\samples\\PalletSamples.py:ExplicitCratePallet",
+            "success": true,
+            "message": "This pallet only runs on Fridays.",
+            "crates": [{
+                "name": "FeatureClassOne",
+                "result": "Data updated successfully."
+            }]
+        }, {
+            "name": "Z:\\forklift\\samples\\PalletSamples.py:SdeCratePallet",
+            "success": true,
+            "message": null,
+            "crates": [{
+                "name": "FeatureClassOne",
+                "result": "Data updated successfully."
+            }]
+        }
+    ]
+}

--- a/tests/data/report_with_errors.json
+++ b/tests/data/report_with_errors.json
@@ -15,7 +15,9 @@
                 "result": "Created table successfully."
             }, {
                 "name": "FeatureClassTwo",
-                "result": "Created table successfully."
+                "result": "Created table successfully.",
+                "crate_message": "Destination has zero records",
+                "message_level": "warning"
             }]
         }, {
             "name": "Z:\\forklift\\samples\\PalletSamples.py:ExplicitCratePallet",
@@ -23,7 +25,8 @@
             "message": "This pallet only runs on Fridays.",
             "crates": [{
                 "name": "FeatureClassOne",
-                "result": "Data updated successfully."
+                "result": "Data updated successfully.",
+                "message_level": ""
             }]
         }, {
             "name": "Z:\\forklift\\samples\\PalletSamples.py:OneValueTupleCratePallet",
@@ -32,7 +35,8 @@
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data is invalid",
-                "crate_message": "a very long message with a stack trace and all sorts of errors a very long message with a stack trace and all sorts of errors"
+                "crate_message": "a very long message with a stack trace and all sorts of errors a very long message with a stack trace and all sorts of errors",
+                "message_level": "error"
             }, {
                 "name": "FeatureClassOne",
                 "result": "Created table successfully."
@@ -47,7 +51,8 @@
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data is invalid",
-                "crate_message": "schema change..."
+                "crate_message": "schema change...",
+                "message_level": "error"
             }]
         }, {
             "name": "Z:\\forklift\\samples\\PalletSamples.py:SdeCratePallet",

--- a/tests/data/report_with_errors.json
+++ b/tests/data/report_with_errors.json
@@ -2,6 +2,7 @@
     "num_success_pallets": 3,
     "total_pallets": 5,
     "copy_results": "Services will not stop: Roadkill/Overlays.MapServer, Roadkill/AnotherService.GPServer. This will affect data copy. Services will not start: Roadkill/Overlays.MapServer.",
+    "static_copy_results": "Static copy error",
     "total_time": "4.5 hours",
     "git_errors": ["Git update error for agrc/oil-gas-mining: raise GitCommandError(self.args, status, errstr)\n', GitCommandError: 'git pull -v origin' returned with exit code 1"],
     "pallets": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,9 +250,10 @@ class TestReport(unittest.TestCase):
     def test_format_dictionary(self):
         #: run with --nocapture and look at tox console output
         good_crate = {'name': 'Good-Crate', 'result': Crate.CREATED, 'crate_message': None}
-        bad_crate = {'name': 'Bad-Crate', 'result': Crate.UNHANDLED_EXCEPTION, 'crate_message': 'This thing blew up.'}
+        bad_crate = {'name': 'Bad-Crate', 'result': Crate.UNHANDLED_EXCEPTION, 'crate_message': 'This thing blew up.', 'message_level': 'error'}
+        warn_crate = {'name': 'Warn-Crate', 'result': Crate.WARNING, 'crate_message': 'This thing almost blew up.', 'message_level': 'warning'}
 
-        success = {'name': 'Successful Pallet', 'success': True, 'message': None, 'crates': [good_crate, good_crate]}
+        success = {'name': 'Successful Pallet', 'success': True, 'message': None, 'crates': [good_crate, good_crate, warn_crate]}
         fail = {'name': 'Fail Pallet', 'success': False, 'message': 'What Happened?!', 'crates': [bad_crate, good_crate]}
 
         report = {'total_pallets': 2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,7 +260,8 @@ class TestReport(unittest.TestCase):
                   'git_errors': ['a git error'],
                   'pallets': [success, fail],
                   'total_time': '5 minutes',
-                  'copy_results': []}
+                  'copy_results': 'copy error',
+                  'static_copy_results': 'static copy error'}
 
         print(cli._format_dictionary(report))
 

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -183,3 +183,26 @@ class TestCrate(unittest.TestCase):
         self.assertEqual(crate.source_name, name)
         self.assertEqual(crate.destination_name, 'Counties')
         self.assertEqual(crate.source, path.join(crate.source_workspace, crate.source_name))
+
+    def test_get_report(self):
+        crate = Crate('foo', 'bar', 'baz', 'goo')
+
+        crate.result = (Crate.NO_CHANGES, None)
+
+        self.assertIsNone(crate.get_report())
+
+        msg = 'blah'
+        crate.result = (Crate.CREATED, msg)
+
+        self.assertEqual(crate.get_report()['crate_message'], msg)
+
+        crate.result = (Crate.WARNING, msg)
+
+        self.assertEqual(crate.get_report()['result'], Crate.WARNING)
+        self.assertEqual(crate.get_report()['message_level'], 'warning')
+
+        crate.result = (Crate.UNHANDLED_EXCEPTION, msg)
+        self.assertEqual(crate.get_report()['message_level'], 'error')
+
+        crate.result = (Crate.INVALID_DATA, msg)
+        self.assertEqual(crate.get_report()['message_level'], 'error')

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -280,7 +280,7 @@ class TestLift(unittest.TestCase):
         p2 = Pallet()
         p3 = Pallet()
 
-        report = lift.create_report_object([p1, p2, p3], 10, copy_results, git_errors)
+        report = lift.create_report_object([p1, p2, p3], 10, copy_results, git_errors, '')
 
         self.assertEqual(report['total_pallets'], 3)
         self.assertEqual(report['num_success_pallets'], 2)


### PR DESCRIPTION
## Description of Changes
The pull request enhances the reports (both email/HTML and command line) to be easier to read. It also adds:
- the ability for crates to report warnings paving the way for #128 & #185.
- fixes the annoying thin red line showing up at the top of successful reports (see b00e02e):
![image](https://user-images.githubusercontent.com/1326248/29718548-5e59acc2-8970-11e7-8956-a4c5c66e380d.png)

Example Reports:
![image](https://user-images.githubusercontent.com/1326248/29729690-65eb5b78-899a-11e7-936e-06c206a121d9.png)
![image](https://user-images.githubusercontent.com/1326248/29729708-791a5348-899a-11e7-8089-5ea23e44f246.png)

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/29728836-d66684e4-8996-11e7-9a48-3efbe7b129cb.png)

![image](https://user-images.githubusercontent.com/1326248/29724725-cdcb8e84-8986-11e7-99df-86b6aab6ffd8.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/29729430-51236ec0-8999-11e7-96b3-7a56c9293356.png)
