### PR TITLE
Warnings are not errors

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -137,11 +137,9 @@ def update(crate, validate_crate):
             change_status = (Crate.WARNING, 'Duplicate features detected!')
 
         #: sanity check the row counts between source and destination
-        count_status, count_message = _check_counts(crate, changes)
-        if not count_status:
-            return (Crate.WARNING, count_message)
+        count_status = _check_counts(crate, changes)
 
-        return change_status
+        return count_status or change_status
     except Exception as e:
         log.error('unhandled exception: %s for crate %r', e, crate, exc_info=True)
 
@@ -389,13 +387,11 @@ def _check_counts(crate, changes):
     source_rows = changes.total_rows
 
     if not source_rows == destination_rows:
-        message = 'Source row count ({}) does not match destination count ({})!'.format(source_rows, destination_rows)
+        return (Crate.WARNING, 'Source row count ({}) does not match destination count ({})!'.format(source_rows, destination_rows))
     elif destination_rows == 0:
-        message = 'Destination has zero rows!'
-    else:
-        message = ''
+        return (Crate.INVALID_DATA, 'Destination has zero rows!')
 
-    return (message == '', message)
+    return None
 
 
 def _mirror_fields(source, destination):

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -171,7 +171,7 @@ class Pallet(object):
 
         returns: Boolean'''
         for crate in self._crates:
-            if crate.result[0] in [Crate.INVALID_DATA, Crate.UNHANDLED_EXCEPTION, Crate.WARNING]:
+            if crate.result[0] in [Crate.INVALID_DATA, Crate.UNHANDLED_EXCEPTION]:
                 return False
 
         return True

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -161,7 +161,7 @@ class Pallet(object):
             if crate.result[0] in [Crate.INVALID_DATA, Crate.UNHANDLED_EXCEPTION]:
                 return False
             if not has_updated:
-                has_updated = crate.result[0] in [Crate.UPDATED, Crate.CREATED]
+                has_updated = crate.result[0] in [Crate.UPDATED, Crate.CREATED, Crate.WARNING]
 
         return has_updated
 


### PR DESCRIPTION
the tests hang for me. I pip installed multiprocess but it still hug on 

```
(forklift) λ nosetests --with-id --rednose --cov-config .coveragerc --with-coverage --cover-package forklift --cov-report term-missing --cover-erase
........................................Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named 'multiprocess'
```
