### PR TITLE
Skip copy

### DIFF
--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -11,7 +11,7 @@ Usage:
     forklift config set --key <key> --value <value>
     forklift garage open
     forklift git-update
-    forklift lift [<file-path>] [--pallet-arg <arg>] [--verbose]
+    forklift lift [<file-path>] [--pallet-arg <arg>] [--skip-copy] [--verbose]
     forklift list-pallets
     forklift scorched-earth
     forklift speedtest
@@ -32,6 +32,7 @@ Examples:
     forklift git-update                                     Pulls the latest updates to all git repositories.
     forklift lift                                           The main entry for running all of pallets found in the warehouse folder.
     forklift lift --verbose                                 Print DEBUG statements to the console.
+    forklift lift --skip-copy                               Skip copying to `copyDestinations`.
     forklift lift path/to/pallet_file.py                    Run a specific pallet.
     forklift lift path/to/pallet_file.py --pallet-arg arg   Run a specific pallet with "arg" as an initialization parameter.
     forklift list-pallets                                   Outputs the list of pallets from the config.
@@ -92,11 +93,11 @@ def main():
     elif args['lift']:
         if args['<file-path>']:
             if args['--pallet-arg']:
-                cli.start_lift(args['<file-path>'], args['<arg>'])
+                cli.start_lift(args['<file-path>'], args['<arg>'], skip_copy=args['--skip-copy'])
             else:
-                cli.start_lift(args['<file-path>'])
+                cli.start_lift(args['<file-path>'], skip_copy=args['--skip-copy'])
         else:
-            cli.start_lift()
+            cli.start_lift(skip_copy=args['--skip-copy'])
     elif args['list-pallets']:
         pallets = cli.list_pallets()
 

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -7,13 +7,14 @@ A module that contains a class to control arcgis services.
 '''
 
 import logging
-import requests
-from multiprocess import Pool
 from os import environ
-from time import sleep
-from time import time
-from . import config
+from time import sleep, time
 
+from multiprocess import Pool
+
+import requests
+
+from . import config
 
 log = logging.getLogger('forklift')
 
@@ -83,7 +84,10 @@ class LightSwitch(object):
             tries -= 1
 
             num_processes = environ.get('FORKLIFT_POOL_PROCESSES')
-            pool = Pool(num_processes or config.default_num_processes)
+            swimmers = num_processes or config.default_num_processes
+            if swimmers > len(affected_services):
+                swimmers = len(affected_services)
+            pool = Pool(swimmers)
 
             log.debug('affected services: %s', get_service_names(affected_services))
             affected_services = [service for service in pool.map(act_on_service, affected_services) if service is not None]

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -87,11 +87,9 @@ class LightSwitch(object):
             swimmers = num_processes or config.default_num_processes
             if swimmers > len(affected_services):
                 swimmers = len(affected_services)
-            pool = Pool(swimmers)
-
-            log.debug('affected services: %s', get_service_names(affected_services))
-            affected_services = [service for service in pool.map(act_on_service, affected_services) if service is not None]
-            pool.close()
+            with Pool(swimmers) as pool:
+                log.debug('affected services: %s', get_service_names(affected_services))
+                affected_services = [service for service in pool.map(act_on_service, affected_services) if service is not None]
 
             if len(affected_services) > 0:
                 log.debug('retrying %s', get_service_names(affected_services))

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -126,6 +126,10 @@ def start_lift(file_path=None, pallet_arg=None, skip_git=False, skip_copy=False)
         static_copy_results = ''
         log.info('copy data and post copy processing were skipped')
 
+    # log process times for each pallet
+    for pallet in pallets_to_lift:
+        log.debug('processing_times (in seconds) for %r: %s', pallet, pallet.processing_times)
+
     elapsed_time = seat.format_time(clock() - start_seconds)
     report_object = lift.create_report_object(pallets_to_lift, elapsed_time, copy_results, git_errors, static_copy_results)
 
@@ -322,7 +326,7 @@ def _format_dictionary(pallet_reports):
         if not report['success']:
             color = Fore.RED
 
-        report_str += '{3}{0}{1}{2}{3}'.format(color, report['name'], Fore.RESET, linesep)
+        report_str += '{3}{0}{1} ({4}){2}{3}'.format(color, report['name'], Fore.RESET, linesep, report['total_processing_time'])
 
         if report['message']:
             report_str += 'pallet message: {}{}{}{}'.format(Fore.RED, report['message'], Fore.RESET, linesep)

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -79,7 +79,7 @@ def list_repos():
     return validate_results
 
 
-def start_lift(file_path=None, pallet_arg=None, skip_git=False):
+def start_lift(file_path=None, pallet_arg=None, skip_git=False, skip_copy=False):
     log.info('starting forklift')
 
     if not skip_git:
@@ -104,22 +104,27 @@ def start_lift(file_path=None, pallet_arg=None, skip_git=False):
     lift.process_pallets(pallets_to_lift)
     log.info('process_pallets time: %s', seat.format_time(clock() - start_process))
 
-    start_copy = clock()
-    copy_destinations = config.get_config_prop('copyDestinations')
-    copy_results = lift.copy_data(pallets_to_lift, all_pallets, copy_destinations)
-    log.info('copy_data time: %s', seat.format_time(clock() - start_copy))
+    if not skip_copy:
+        start_copy = clock()
+        copy_destinations = config.get_config_prop('copyDestinations')
+        copy_results = lift.copy_data(pallets_to_lift, all_pallets, copy_destinations)
+        log.info('copy_data time: %s', seat.format_time(clock() - start_copy))
 
-    start_post_copy_process = clock()
-    lift.process_pallets(pallets_to_lift, is_post_copy=True)
-    log.info('post_copy_process time: %s', seat.format_time(clock() - start_post_copy_process))
+        start_post_copy_process = clock()
+        lift.process_pallets(pallets_to_lift, is_post_copy=True)
+        log.info('post_copy_process time: %s', seat.format_time(clock() - start_post_copy_process))
 
-    if len(copy_destinations) == 0:
-        log.info('No `copyDestinations` defined in the config. Skipping update_static...')
-        static_copy_results = ''
+        if len(copy_destinations) == 0:
+            log.info('No `copyDestinations` defined in the config. Skipping update_static...')
+            static_copy_results = ''
+        else:
+            start_static = clock()
+            static_copy_results = lift.update_static_for(pallets_to_lift, copy_destinations, False)
+            log.info('static copy time: %s', seat.format_time(clock() - start_static))
     else:
-        start_static = clock()
-        static_copy_results = lift.update_static_for(pallets_to_lift, copy_destinations, False)
-        log.info('static copy time: %s', seat.format_time(clock() - start_static))
+        copy_results = 'Copying to copyDestinations was skipped!'
+        static_copy_results = ''
+        log.info('copy data and post copy processing were skipped')
 
     elapsed_time = seat.format_time(clock() - start_seconds)
     report_object = lift.create_report_object(pallets_to_lift, elapsed_time, copy_results, git_errors, static_copy_results)

--- a/src/forklift/cli.py
+++ b/src/forklift/cli.py
@@ -227,9 +227,8 @@ def git_update():
     if swimmers > num_repos:
         swimmers = num_repos
 
-    pool = Pool(swimmers)
-
-    results = pool.map(_clone_or_pull_repo, repositories)
+    with Pool(swimmers) as pool:
+        results = pool.map(_clone_or_pull_repo, repositories)
 
     for error, info in results:
         if info is not None:

--- a/src/forklift/report_template.html
+++ b/src/forklift/report_template.html
@@ -10,6 +10,10 @@
     .warning {
       background-color: #fcc573;
     }
+    .pull-right {
+      float: right;
+      margin-left: 20px;
+    }
   </style>
 </head>
 <p><b>{{num_success_pallets}}</b> out of <b>{{total_pallets}}</b> pallets ran successfully in <b>{{total_time}}</b> on {{hostname}}.</p>
@@ -35,6 +39,9 @@
     <tr>
       <td colspan="2" class="{{#success}}success{{/success}}{{^success}}error{{/success}}">
         {{name}}
+        <span class="pull-right">
+          {{total_processing_time}}
+        </span>
       </td>
     </tr>
     <tr>

--- a/src/forklift/seat.py
+++ b/src/forklift/seat.py
@@ -21,3 +21,15 @@ def format_time(seconds):
         return '{} minutes'.format(round(seconds / minute, 2))
 
     return '{} hours'.format(round(seconds / hour, 2))
+
+
+class timed_pallet_process(object):
+    def __init__(self, pallet, name):
+        self.pallet = pallet
+        self.name = name
+
+    def __enter__(self):
+        self.pallet.start_timer(self.name)
+
+    def __exit__(self, type, value, traceback):
+        self.pallet.stop_timer(self.name)

--- a/tests/data/report_success.json
+++ b/tests/data/report_success.json
@@ -11,6 +11,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:StringCratePallet",
             "success": true,
             "message": null,
+            "total_processing_time": "1 hour",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Created table successfully."
@@ -22,6 +23,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:ExplicitCratePallet",
             "success": true,
             "message": "This pallet only runs on Fridays.",
+            "total_processing_time": "0 seconds",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data updated successfully."
@@ -30,6 +32,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:SdeCratePallet",
             "success": true,
             "message": null,
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data updated successfully."

--- a/tests/data/report_with_errors.json
+++ b/tests/data/report_with_errors.json
@@ -11,6 +11,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:StringCratePallet",
             "success": true,
             "message": null,
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Created table successfully."
@@ -24,6 +25,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:ExplicitCratePallet",
             "success": true,
             "message": "This pallet only runs on Fridays.",
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data updated successfully.",
@@ -33,6 +35,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:OneValueTupleCratePallet",
             "success": false,
             "message": "pallet failed to run because it broke",
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data is invalid",
@@ -49,6 +52,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:ShapefileCratePallet",
             "success": false,
             "message": "warehouse fire",
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data is invalid",
@@ -59,6 +63,7 @@
             "name": "Z:\\forklift\\samples\\PalletSamples.py:SdeCratePallet",
             "success": true,
             "message": null,
+            "total_processing_time": "45 minutes",
             "crates": [{
                 "name": "FeatureClassOne",
                 "result": "Data updated successfully."

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -40,8 +40,11 @@ class SpatialReference(object):
 
 
 class PoolMock(object):
-    def map(*args):
+    def map(self, *args):
         return list(map(*args))
 
-    def close():
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
         pass

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -7,11 +7,12 @@ A module that tests arcgis.py
 '''
 
 import unittest
-from forklift.arcgis import LightSwitch
-from mock import Mock
-from mock import patch
-from mock import call
 from time import time
+
+from mock import Mock, call, patch
+
+from forklift.arcgis import LightSwitch
+
 from .mocks import PoolMock
 
 
@@ -119,7 +120,7 @@ class TestLightSwitch(unittest.TestCase):
         self.assertEqual(self.patient.token, 'token1')
         self.assertEqual(self.patient.token_expire_milliseconds, 123)
 
-    @patch('forklift.arcgis.Pool', return_value=PoolMock)
+    @patch('forklift.arcgis.Pool', return_value=PoolMock())
     @patch('forklift.arcgis.sleep')
     def test_ensure_tries_five_times_with_failures(self, sleep, poolmock):
         affected_services = [('1', 'MapServer')]
@@ -135,7 +136,7 @@ class TestLightSwitch(unittest.TestCase):
         self.patient.turn_off.assert_not_called()
         sleep.assert_has_calls([call(1), call(2), call(3), call(5), call(8)])
 
-    @patch('forklift.arcgis.Pool', return_value=PoolMock)
+    @patch('forklift.arcgis.Pool', return_value=PoolMock())
     @patch('forklift.arcgis.sleep')
     def test_ensure_returns_formatted_problems(self, sleep, poolmock):
         affected_services = [('1', 'MapServer'), ('2', 'GPServer'), ('3', 'GeocodeServer')]
@@ -147,7 +148,7 @@ class TestLightSwitch(unittest.TestCase):
 
         self.assertEqual('1.MapServer, 2.GPServer, 3.GeocodeServer', affected_services)
 
-    @patch('forklift.arcgis.Pool', return_value=PoolMock)
+    @patch('forklift.arcgis.Pool', return_value=PoolMock())
     @patch('forklift.arcgis.sleep')
     def test_ensure_tries_until_success(self, sleep, poolmock):
         affected_services = [('1', 'MapServer')]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,7 +248,7 @@ class TestGitUpdate(unittest.TestCase):
         if exists(config_location):
             remove(config_location)
 
-    @patch('forklift.cli.Pool', return_value=PoolMock)
+    @patch('forklift.cli.Pool', return_value=PoolMock())
     @patch('git.Repo.clone_from')
     @patch('forklift.cli._get_repo')
     @patch('forklift.cli._validate_repo')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,13 +40,15 @@ class TestConfigInit(unittest.TestCase):
 
         with open(path) as config:
             config_dict = loads(config.read())
-            self.assertEqual(config_dict, {u"configuration": u"Production",
-                                           u"warehouse": u"c:\\scheduled\\warehouse",
-                                           u"repositories": [],
-                                           u"copyDestinations": [],
-                                           u"stagingDestination": u"c:\\scheduled\\staging",
-                                           u"sendEmails": False,
-                                           u"notify": [u"stdavis@utah.gov", u"sgourley@utah.gov"]})
+            self.assertEqual(config_dict, {
+                u"configuration": u"Production",
+                u"warehouse": u"c:\\scheduled\\warehouse",
+                u"repositories": [],
+                u"copyDestinations": [],
+                u"stagingDestination": u"c:\\scheduled\\staging",
+                u"sendEmails": False,
+                u"notify": [u"stdavis@utah.gov", u"sgourley@utah.gov"]
+            })
 
     def test_init_returns_path_for_existing_config_file(self):
         self.assertEqual(cli.init(), cli.init())
@@ -277,16 +279,30 @@ class TestReport(unittest.TestCase):
         bad_crate = {'name': 'Bad-Crate', 'result': Crate.UNHANDLED_EXCEPTION, 'crate_message': 'This thing blew up.', 'message_level': 'error'}
         warn_crate = {'name': 'Warn-Crate', 'result': Crate.WARNING, 'crate_message': 'This thing almost blew up.', 'message_level': 'warning'}
 
-        success = {'name': 'Successful Pallet', 'success': True, 'message': None, 'crates': [good_crate, good_crate, warn_crate]}
-        fail = {'name': 'Fail Pallet', 'success': False, 'message': 'What Happened?!', 'crates': [bad_crate, good_crate]}
+        success = {
+            'name': 'Successful Pallet',
+            'success': True,
+            'message': None,
+            'crates': [good_crate, good_crate, warn_crate],
+            'total_processing_time': '1 hr'
+        }
+        fail = {
+            'name': 'Fail Pallet',
+            'success': False,
+            'message': 'What Happened?!',
+            'crates': [bad_crate, good_crate],
+            'total_processing_time': '2 hrs'
+        }
 
-        report = {'total_pallets': 2,
-                  'num_success_pallets': 1,
-                  'git_errors': ['a git error'],
-                  'pallets': [success, fail],
-                  'total_time': '5 minutes',
-                  'copy_results': 'copy error',
-                  'static_copy_results': 'static copy error'}
+        report = {
+            'total_pallets': 2,
+            'num_success_pallets': 1,
+            'git_errors': ['a git error'],
+            'pallets': [success, fail],
+            'total_time': '5 minutes',
+            'copy_results': 'copy error',
+            'static_copy_results': 'static copy error'
+        }
 
         print(cli._format_dictionary(report))
 

--- a/tests/test_pallet.py
+++ b/tests/test_pallet.py
@@ -7,8 +7,11 @@ A module that contains tests for the pallet module.
 '''
 
 import unittest
-from forklift.models import Pallet, Crate
+from time import sleep
+
 from mock import patch
+
+from forklift.models import Crate, Pallet
 
 
 class TestPallet(unittest.TestCase):
@@ -316,3 +319,20 @@ class TestPalletGetReport(unittest.TestCase):
         self.assertEqual(len(report['crates']), 3)
         self.assertEqual(report['crates'][1]['result'], Crate.INVALID_DATA)
         self.assertEqual(report['crates'][1]['crate_message'], 'Invalid data message')
+
+    def test_processing_time(self):
+        pallet = Pallet()
+        first = 'first'
+        second = 'second'
+
+        pallet.start_timer(first)
+        sleep(2)
+        pallet.stop_timer(first)
+
+        pallet.start_timer(second)
+        sleep(3)
+        pallet.stop_timer(second)
+
+        self.assertEqual(round(pallet.total_processing_time), 5)
+        self.assertEqual(round(pallet.processing_times[first]), 2)
+        self.assertEqual(round(pallet.processing_times[second]), 3)


### PR DESCRIPTION
## Description of Changes
This pull request contains three enhancements:
1. Prevents creating more parallel processes than we had items to act upon.
1. Adds a `--skip-copy` flag to `lift` to prevent copying data to production.
1. Adds process time reporting to pallets in the HTML and console reports as well as a more detailed break out as debug statements in the log.

I really wanted to implement the time tracking directly on pallet methods via decorators. However, I found out that the decorates are lost if you override the method on a class. I also tried it via a decorator on the class but found that the decorator was lost when the class is inherited from.

![image](https://user-images.githubusercontent.com/1326248/33504206-cd705cfc-d6a3-11e7-879c-9ebb18f81be9.png)

![image](https://user-images.githubusercontent.com/1326248/33504193-c040df52-d6a3-11e7-976a-81ae17b00313.png)

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/33503393-c6f923ac-d6a0-11e7-843f-047dd42836e8.png)
![image](https://user-images.githubusercontent.com/1326248/33503396-c9d143fc-d6a0-11e7-928d-4e6d87ad0209.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/33503400-ce46b8e0-d6a0-11e7-8751-396ac420cf9e.png)
