### PR TITLE
Add 30 second timeout to requests

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -114,12 +114,18 @@ class LightSwitch(object):
         if self.token_expire_milliseconds <= time() * 1000:
             self._request_token()
 
+        ok = False
         data = {'f': 'json', 'token': self.token}
+        
+        try:
+            r = requests.post(url, data=data, timeout=30)
+            r.raise_for_status()
 
-        r = requests.post(url, data=data)
-        r.raise_for_status()
-
-        ok = self._return_false_for_status(r.json())
+            ok = self._return_false_for_status(r.json())
+        except requests.exceptions.Timeout:
+            return False
+        except requests.exceptions.ConnectTimeout:
+            return False
 
         sleep(3.0)
 


### PR DESCRIPTION
## Description of Changes
This pull requests adds a timeout to requests

### Test results and coverage

```
Name                 Stmts   Miss     Cover   Missing
-----------------------------------------------------
forklift\arcgis.py      94     16    82.98%   34-44, 71, 125-128, 137-139
forklift\cli.py        264     51    80.68%   88, 125-126, 206-211, 244, 349-360, 364-373, 383-424
forklift\core.py       182      2    98.90%   119, 324
forklift\lift.py       166     24    85.54%   179-199, 209-211, 223-225, 240, 248-250, 284, 299
forklift\models.py     191      8    95.81%   99, 294-297, 353, 397-398
-----------------------------------------------------
TOTAL                  997    101    89.87%

5 files skipped due to complete coverage.
-----------------------------------------------------------------------------
161 tests run in 353.896 seconds.
10 skipped (151 tests passed)
```

### Speed test results

```
Speed Test Results
Dry Run: 4.15 minutes
Repeat: 3.1 minutes
```
