### PR TITLE
Revert "allow for easier testing"

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -10,10 +10,11 @@ import logging
 from os import environ
 from time import sleep, time
 
+from multiprocess import Pool
+
 import requests
 
-import config
-from multiprocess import Pool
+from . import config
 
 log = logging.getLogger('forklift')
 


### PR DESCRIPTION
This reverts commit 83fd9c664e3e90eae714b146fdcaa62e13b8df5c.

I think that the way that we are doing it is correct. Ref: https://docs.python.org/3/tutorial/modules.html#intra-package-references

![image](https://user-images.githubusercontent.com/1326248/34569601-7fb4981e-f126-11e7-9d8c-1a1c5f733801.png)

![image](https://user-images.githubusercontent.com/1326248/34569609-881347f8-f126-11e7-9fec-2a714441ce49.png)
