### PR TITLE
increase arcgis server request timeout from 30 to 60 seconds

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -118,7 +118,7 @@ class LightSwitch(object):
         data = {'f': 'json', 'token': self.token}
 
         try:
-            r = requests.post(url, data=data, timeout=30)
+            r = requests.post(url, data=data, timeout=60)
             r.raise_for_status()
 
             ok = self._return_false_for_status(r.json())


### PR DESCRIPTION
## Description of Changes
This pull request increases the timeout for the start and stop service requests to ArcGIS Server. We had a bunch of services returned from forklift as unable to start this morning. However, when I went to check on them, all but one were started. Hopefully, this will prevent forklift crying wolf in the future.

### Test results and coverage
I didn't feel like this change was worth running any.
  