### PR TITLE
[WIP] increase timeout for starting/stopping service request

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -118,7 +118,7 @@ class LightSwitch(object):
         data = {'f': 'json', 'token': self.token}
 
         try:
-            r = requests.post(url, data=data, timeout=60)
+            r = requests.post(url, data=data, timeout=120)
             r.raise_for_status()
 
             ok = self._return_false_for_status(r.json())


### PR DESCRIPTION
## Description of Changes
This pull request increases the timeout for the start/stop of ArcGIS Server services. The last few days we've been getting errors in forklift that report services not starting successfully. However, when I go to check them they are started.

### Test results and coverage
n/a

### Speed test results
n/a