### PR TITLE
add -skip-emails optional parameter

### DIFF
--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -11,7 +11,7 @@ Usage:
     forklift config set --key <key> --value <value>
     forklift garage open
     forklift git-update
-    forklift lift [<file-path>] [--pallet-arg <arg>] [--skip-copy] [--verbose] [--skip-emails]
+    forklift lift [<file-path>] [--pallet-arg <arg>] [--skip-copy] [--verbose] [--skip-emails|--send-emails]
     forklift list-pallets
     forklift scorched-earth
     forklift speedtest
@@ -33,7 +33,8 @@ Examples:
     forklift lift                                           The main entry for running all of pallets found in the warehouse folder.
     forklift lift --verbose                                 Print DEBUG statements to the console.
     forklift lift --skip-copy                               Skip copying to `copyDestinations`.
-    forklift lift --skip-emails                             Skip sending emails.
+    forklift lift --skip-emails                             Skip sending emails. Overrides `sendEmails` config as False.
+    forklift lift --send-emails                             Force sending emails. Overrides `sendEmails` config as True.
     forklift lift path/to/pallet_file.py                    Run a specific pallet.
     forklift lift path/to/pallet_file.py --pallet-arg arg   Run a specific pallet with "arg" as an initialization parameter.
     forklift list-pallets                                   Outputs the list of pallets from the config.
@@ -73,7 +74,9 @@ def main():
     _add_global_error_handler()
 
     if args['--skip-emails']:
-        messaging.skip_emails = True
+        messaging.send_emails_override = False
+    elif args['--send-emails']:
+        messaging.send_emails_override = True
 
     if args['config']:
         if args['init']:

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -7,18 +7,19 @@ A module that contains a method for sending emails
 '''
 
 import gzip
-import logging
 import io
-from .config import get_config_prop
+import logging
 from email.mime.application import MIMEApplication
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from os import environ
-from os.path import basename
-from os.path import isfile
+from os.path import basename, isfile
 from smtplib import SMTP
 
+from .config import get_config_prop
+
 log = logging.getLogger('forklift')
+skip_emails = False
 
 
 def send_email(to, subject, body, attachment=''):
@@ -64,7 +65,7 @@ def send_email(to, subject, body, attachment=''):
 
             message.attach(log_file_attachment)
 
-    if get_config_prop('sendEmails'):
+    if get_config_prop('sendEmails') and not skip_emails:
         smtp = SMTP(smtp_server, smtp_port)
         smtp.sendmail(from_address, to, message.as_string())
         smtp.quit()

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -19,7 +19,7 @@ from smtplib import SMTP
 from .config import get_config_prop
 
 log = logging.getLogger('forklift')
-skip_emails = False
+send_emails_override = None
 
 
 def send_email(to, subject, body, attachment=''):
@@ -65,7 +65,8 @@ def send_email(to, subject, body, attachment=''):
 
             message.attach(log_file_attachment)
 
-    if get_config_prop('sendEmails') and not skip_emails:
+    if (send_emails_override is None and get_config_prop('sendEmails')) or \
+            (send_emails_override is not None and send_emails_override):
         smtp = SMTP(smtp_server, smtp_port)
         smtp.sendmail(from_address, to, message.as_string())
         smtp.quit()


### PR DESCRIPTION
## Description of Changes
This pull request adds a new optional parameter (`--skip-emails`) to the `lift` command for temporarily switching off the sending of emails. This will prevent the situation where absent-minded people, such as myself, forget to update the switch in the config file.

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/36544898-d187ce00-17a4-11e8-83bf-d914efb7fa3e.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/36546282-3fb51e34-17a8-11e8-898f-c06c1fc388a6.png)
