### PR TITLE
Add `ERROR` result type to crate

### DIFF
--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -229,6 +229,7 @@ class Crate(object):
     NO_CHANGES = 'No changes found.'
     UNHANDLED_EXCEPTION = 'Unhandled exception during update.'
     UNINITIALIZED = 'This crate was never processed.'
+    ERROR = 'There was an error.' #: This can be used to manually set an error on a crate from within a pallet.
 
     def __init__(self,
                  source_name,


### PR DESCRIPTION
We need a way to manually set an error on a crate from within a pallet. For example:
https://github.com/agrc/warehouse/blob/8e195f69dc4097efb12fc5326b0e3d1ebc95f002/sgid/AGOLPallet.py#L84

I didn't think that `UNHANDLED_EXCEPTION` was a good fit.