### PR TITLE
report should be based on pallet.success not is_ready_to_ship

### DIFF
--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -520,7 +520,7 @@ def _generate_packing_slip(status, location):
     this pulls the pallet status from the report object and writes it to a file in the drop off location
     for later use by the ship command
     '''
-    status = status['pallets']
+    status = [report for report in status['pallets'] if report['is_ready_to_ship']]
 
     if not exists(location):
         return

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -211,6 +211,7 @@ class Pallet(object):
         return {
             'name': self.name,
             'success': self.success[0] and self.are_crates_valid(),
+            'is_ready_to_ship': self.is_ready_to_ship(),
             'requires_processing': self.requires_processing(),
             'message': self.success[1] or '',
             'crates': [crate.get_report() for crate in self._crates if crate.get_report() is not None],

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -210,7 +210,7 @@ class Pallet(object):
         '''
         return {
             'name': self.name,
-            'success': self.success[0],
+            'success': self.success[0] and self.are_crates_valid(),
             'requires_processing': self.requires_processing(),
             'message': self.success[1] or '',
             'crates': [crate.get_report() for crate in self._crates if crate.get_report() is not None],

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -210,7 +210,7 @@ class Pallet(object):
         '''
         return {
             'name': self.name,
-            'success': self.is_ready_to_ship(),
+            'success': self.success[0],
             'requires_processing': self.requires_processing(),
             'message': self.success[1] or '',
             'crates': [crate.get_report() for crate in self._crates if crate.get_report() is not None],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,10 +12,9 @@ from os import makedirs, remove, rmdir
 from os.path import abspath, dirname, exists, join
 
 import pytest
-from mock import Mock, mock_open, patch
-
 from forklift import config, core, engine
 from forklift.models import Crate
+from mock import Mock, mock_open, patch
 
 from .mocks import PoolMock
 
@@ -362,16 +361,39 @@ class TestPackingSlip(unittest.TestCase):
             'success': True,
             'message': None,
             'crates': [good_crate, good_crate, warn_crate],
-            'total_processing_time': '1 hr'
+            'total_processing_time': '1 hr',
+            'is_ready_to_ship': True
         }
-        fail = {'name': 'Fail Pallet', 'success': False, 'message': 'What Happened?!', 'crates': [bad_crate, good_crate], 'total_processing_time': '2 hrs'}
+        fail = {
+            'name': 'Fail Pallet',
+            'success': False,
+            'message': 'What Happened?!',
+            'crates': [bad_crate, good_crate],
+            'total_processing_time': '2 hrs',
+            'is_ready_to_ship': True
+        }
+        not_ready_to_ship = {
+            'name': 'Successful Pallet',
+            'success': True,
+            'message': None,
+            'crates': [good_crate, good_crate, warn_crate],
+            'total_processing_time': '1 hr',
+            'is_ready_to_ship': False
+        }
 
-        report = {'total_pallets': 2, 'num_success_pallets': 1, 'git_errors': ['a git error'], 'pallets': [success, fail], 'total_time': '5 minutes'}
+        report = {
+            'total_pallets': 3,
+            'num_success_pallets': 1,
+            'git_errors': ['a git error'],
+            'pallets': [success, fail, not_ready_to_ship],
+            'total_time': '5 minutes'
+        }
 
         engine._generate_packing_slip(report, test_data_folder)
 
         open.assert_called_with(join(test_data_folder, engine.packing_slip_file), 'w', encoding='utf-8')
         dump.assert_called_once()
+        self.assertEqual(len(dump.call_args[0][0]), 2)
 
 
 class TestScorchedEarth(CleanUpAlternativeConfig):


### PR DESCRIPTION
## Description of Changes
This pull request fixes the email report for pallets that use `is_ready_to_ship` to restrict which days that pallet runs. Any ideas on why we used `is_ready_to_ship` to get the success value for the lift report in the first place?

Before PR:
![image](https://user-images.githubusercontent.com/1326248/47307373-1c624300-d5ec-11e8-8ebc-2d420719163d.png)

After PR:
![image](https://user-images.githubusercontent.com/1326248/47307394-271cd800-d5ec-11e8-9185-34e97697f4be.png)

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/47307497-63503880-d5ec-11e8-8849-550561d97d55.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/47307774-191b8700-d5ed-11e8-916d-d2dafd790b3d.png)

