### PR TITLE
Catch all errors

### DIFF
--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -110,7 +110,10 @@ class LightSwitch(object):
 
         Retuns a tuple with a boolean status and a message
         '''
-        self._check_token_freshness()
+        try:
+            self._check_token_freshness()
+        except Exception as t:
+            return (False, str(t))
 
         ok = (False, None)
         data = {'f': 'json', 'token': self.token}

--- a/src/forklift/arcgis.py
+++ b/src/forklift/arcgis.py
@@ -120,11 +120,7 @@ class LightSwitch(object):
             r.raise_for_status()
 
             ok = self._return_false_for_status(r.json())
-        except requests.exceptions.ConnectTimeout as t:
-            return (False, str(t))
-        except requests.exceptions.Timeout as t:
-            return (False, str(t))
-        except requests.exceptions.HTTPError as t:
+        except Exception as t:
             return (False, str(t))
 
         return ok


### PR DESCRIPTION
## Description of Changes

This pull requests broadens the error catching for http requests to server. there is no reason to be specific when returning the same item from each case.

I don't know why arcgis server was refusing connections. but that should not kill the update process. 