### PR TITLE
Remove unused `arcgis_services` pallet property

### DIFF
--- a/samples/TypicalPallet.py
+++ b/samples/TypicalPallet.py
@@ -11,8 +11,6 @@ class TypicalPallet(Pallet):
     def __init__(self):
         super(TypicalPallet, self).__init__()
 
-        self.arcgis_services = [('Service', 'MapServer')]
-
         self.boundaries_utm = path.join(self.staging_rack, 'boundaries_utm.gdb')
 
         self.copy_data = [self.boundaries_utm]

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -44,10 +44,6 @@ class Pallet(object):
         #: a list databases or folders that you want forklift to copy to `dropoffLocations`
         #: after a successful process
         self.copy_data = []
-        #: a list of tuples describing arcgis server services that should be shut down before copying data in `copy_data`
-        #: the format of the tuple is two strings: `('<Folder>/<ServiceName>', '<ServiceType>')`
-        #: for example: `[('PoliticalDistricts', 'MapServer'), ('DEQEnviro/Toolbox', 'GPServer')]`
-        self.arcgis_services = []
         #: default output coordinate system and transformation
         self.destination_coordinate_system = arcpy.SpatialReference(3857)
         self.geographic_transformation = 'NAD_1983_To_WGS_1984_5'

--- a/tests/SchemaLockPallet.py
+++ b/tests/SchemaLockPallet.py
@@ -18,8 +18,6 @@ class SchemaLockedPallet(Pallet):
     def __init__(self):
         super(SchemaLockedPallet, self).__init__()
 
-        self.arcgis_services = [('forklift/SchemaLock', 'MapServer')]
-
         source_workspace = path.join(data_folder, 'NewSchemaData.gdb')
         destination_workspace = path.join(data_folder, 'SchemaLock.gdb')
         copy_to = destination_workspace
@@ -33,8 +31,6 @@ class NoSchemaLockPallet(Pallet):
 
     def __init__(self):
         super(NoSchemaLockPallet, self).__init__()
-
-        self.arcgis_services = [('forklift/NoSchemaLock', 'MapServer')]
 
         source_workspace = path.join(data_folder, 'NewSchemaData.gdb')
         destination_workspace = path.join(data_folder, 'NoSchemaLock.gdb')


### PR DESCRIPTION
## Description of Changes
This pull request removes the `arcgis_services` pallet property that hasn't been used since v9.

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/50708013-10e5bc00-1020-11e9-8fdf-1cfcd252ca61.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/50708357-463ed980-1021-11e9-89ba-a3b28197aa62.png)

