### PR TITLE
fix: allow pallets that don't have any crates to copy data to dropoff

### DIFF
--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -343,15 +343,9 @@ def _get_locations_for_dropoff(pallets):
     destination_to_pallet = {}
 
     for pallet in pallets:
-        if not pallet.success[0]:
-            continue
-
-        for crate in pallet.get_crates():
-            if crate.was_updated():
-                normal_paths = [normalize_workspace(p) for p in pallet.copy_data]
-                for p in normal_paths:
-                    destination_to_pallet.setdefault(p, []).append(pallet)
-
-                break
+        if pallet.success[0] and pallet.requires_processing():
+            normal_paths = [normalize_workspace(p) for p in pallet.copy_data]
+            for p in normal_paths:
+                destination_to_pallet.setdefault(p, []).append(pallet)
 
     return destination_to_pallet


### PR DESCRIPTION
## Description of Changes
This allows for pallets that generate data rather define crates to have 
their data copied to the drop off location by overwriting 
requires_processing (which they are likely already doing anyway).

This was specifically done to help with the new [SureSites pallet](https://github.com/agrc/locate/pull/177).

### Test results and coverage
![image](https://user-images.githubusercontent.com/1326248/50997621-4ab43800-14e2-11e9-810c-8b429bb9bf73.png)

### Speed test results
![image](https://user-images.githubusercontent.com/1326248/50997823-d62dc900-14e2-11e9-9f9d-db5217d7d470.png)
