### PR TITLE
Gift wrap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ From within the [ArcGIS Pro conda environment](http://pro.arcgis.com/en/pro-app/
     - `password` ArcGIS admin password.
     - `host` ArcGIS host address eg: `myserver`. Validate this property by looking at the `machineName` property returned by `/arcgis/admin/machines?f=json`
     - `port` ArcGIS server instance port eg: 6080
+
     ```json
     "servers": {
        "options": {
@@ -117,10 +118,12 @@ From within the [ArcGIS Pro conda environment](http://pro.arcgis.com/en/pro-app/
        }
     }
     ```
+
 1. Edit the `config.json` to add the email notification properties. _(This is required for sending email reports)_
     - `smtpServer` The SMTP server that you want to send emails with.
     - `smtpPort` The SMTP port number.
     - `fromAddress` The from email address for emails sent by forklift.
+
     ```json
     "email": {
         "smtpServer": "smpt.server.address",
@@ -128,6 +131,7 @@ From within the [ArcGIS Pro conda environment](http://pro.arcgis.com/en/pro-app/
         "fromAddress": "noreply@utah.gov"
     }
     ```
+
 1. `forklift lift`
 1. `forklift ship`
 
@@ -162,6 +166,7 @@ _Tests that depend on a local SDE database (see `tests/data/UPDATE_TESTS.bak`) w
 ## Changelog
 
 ### 9.0.1
+
 - Better requests to ArcGIS Server and handling of errors.
 - Docs: Better getting started steps.
 - Removed multiprocess for git-update. Forklift was randomly hanging on git-update.
@@ -175,15 +180,14 @@ _Tests that depend on a local SDE database (see `tests/data/UPDATE_TESTS.bak`) w
 - Added `ERROR` as a possible result type for crates.
 - Removed unused crate property, `source_primary_key`
 - BREAKING CHANGE: Split up lift and ship to be independant commands.
-    - Replaced arcgis server env variables with config.json properties to allow for managing a silo'd architecture or multiple machines not in a cluster
-    - Replaced env variables with config.json properties for consistency.
-    - Ship now shuts down the entire ArcGIS Server machine rather than specific services. It also now does this one machine at time to minimize downtime.
-    - Removed static data processing since it can now be accomplished by dropping the data into the dropoff folder.
+  - Replaced arcgis server env variables with config.json properties to allow for managing a silo'd  architecture or multiple machines not in a cluster
+  - Replaced env variables with config.json properties for consistency.
+  - Ship now shuts down the entire ArcGIS Server machine rather than specific services. It also now does this one machine at time to minimize downtime.
+  - Removed static data processing since it can now be accomplished by dropping the data into the dropoff folder.
 - Removed tox because it's incompatible with conda.
 - Enhanced the remove repo command to also delete the repository folder from disk ([#134](https://github.com/agrc/forklift/issues/134)).
 - Removed the check for python version 3.
 - Switched from nose to pytest for running tests.
-
 
 ### 8.5.0
 

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -15,6 +15,7 @@ Usage:
     forklift ship [--verbose] [--pallet-arg <arg>] [--skip-emails|--send-emails]
     forklift list-pallets
     forklift scorched-earth
+    forklift gift-wrap --output <file-path> [--input <file-path2>]
     forklift speedtest
 
 Arguments:
@@ -40,6 +41,7 @@ Examples:
     forklift list-pallets                                   Outputs the list of pallets from the config.
     forklift scorched-earth                                 WARNING!!! Deletes all data in `config.stagingDestination` as well as the
                                                             `hashes.gdb` & `scratch.gdb` file geodatabases.
+    forklift gift-wrap --output path/to/folder              Gift wraps everything in `config.hashLocation`
     forklift speedtest                                      Test the speed on a predefined pallet.
 '''
 
@@ -120,6 +122,8 @@ def main():
                 print((': '.join([path, str(pallet_class)])))
     elif args['scorched-earth']:
         engine.scorched_earth()
+    elif args['gift-wrap']:
+        engine.gift_wrap(args['<file-path>'], args['<file-path2>'])
     elif args['speedtest']:
         engine.speedtest(speedtest)
 

--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -475,7 +475,9 @@ def gift_wrap(destination, source=None):
         source = config.get_config_prop('hashLocation')
 log.info('copying data from %s to %s', source, destination)
     copytree(source, destination)
+	log.info('gift-wrapping data')
     lift.gift_wrap(destination)
+    log.info('gift-wrapping completed successfully')
 
 
 def _build_pallets(file_path, pallet_arg=None):

--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -15,7 +15,7 @@ from os import linesep, listdir, walk
 from os.path import (abspath, basename, dirname, exists, join, realpath,
                      splitext)
 from re import compile
-from shutil import rmtree
+from shutil import copytree, rmtree
 from time import clock, sleep
 
 import pystache
@@ -465,6 +465,17 @@ def git_update():
             log.error(error)
 
     return [error for error, info in results if error is not None]
+
+
+def gift_wrap(destination, source=None):
+    if exists(destination):
+        destination = join(destination, 'gift-wrapped')
+
+    if source is None:
+        source = config.get_config_prop('hashLocation')
+
+    copytree(source, destination)
+    lift.gift_wrap(destination)
 
 
 def _build_pallets(file_path, pallet_arg=None):

--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -473,7 +473,7 @@ def gift_wrap(destination, source=None):
 
     if source is None:
         source = config.get_config_prop('hashLocation')
-
+log.info('copying data from %s to %s', source, destination)
     copytree(source, destination)
     lift.gift_wrap(destination)
 


### PR DESCRIPTION
## Description of Changes

This pull requests adds a gift-wrap cli option to take an input folder or the hashed folder as a default and gift wraps the gdb's in an output directory with the same logic that lift uses.

This option is a nice-to-have when you want something from the hashed data but don't want to manually remove the fields and compact the gdb.