### PR TITLE
fix: arcpy.Describe -> arcpy.da.Describe

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -187,11 +187,11 @@ def _hash(crate):
         changes.table = arcpy.CreateFeatureclass_management(
             scratch_gdb_path,
             crate.name,
-            geometry_type=crate.source_describe.shapeType.upper(),
+            geometry_type=crate.source_describe['shapeType'].upper(),
             template=crate.source,
             has_m='SAME_AS_TEMPLATE',
             has_z='SAME_AS_TEMPLATE',
-            spatial_reference=crate.source_describe.spatialReference
+            spatial_reference=crate.source_describe['spatialReference']
         )[0]
     else:
         changes.table = arcpy.CreateTable_management(scratch_gdb_path, crate.name)[0]
@@ -270,11 +270,11 @@ def _create_destination_data(crate):
         arcpy.CreateFeatureclass_management(
             crate.destination_workspace,
             crate.destination_name,
-            geometry_type=crate.source_describe.shapeType.upper(),
+            geometry_type=crate.source_describe['shapeType'].upper(),
             template=crate.source,
             has_m='SAME_AS_TEMPLATE',
             has_z='SAME_AS_TEMPLATE',
-            spatial_reference=crate.destination_coordinate_system or crate.source_describe.spatialReference
+            spatial_reference=crate.destination_coordinate_system or crate.source_describe['spatialReference']
         )
 
     arcpy.AddField_management(crate.destination, hash_field, 'TEXT', field_length=hash_field_length)

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -272,7 +272,7 @@ class Crate(object):
         destination_name=None,
         destination_coordinate_system=None,
         geographic_transformation=None,
-        describer=arcpy.Describe
+        describer=arcpy.da.Describe
     ):
         #: the logging module to keep track of the crate
         self.log = logging.getLogger('forklift')
@@ -378,7 +378,7 @@ class Crate(object):
     def is_table(self):
         '''returns True if the crate defines a table
         '''
-        return self.source_describe.datasetType.lower() == 'table'
+        return self.source_describe['datasetType'].lower() == 'table'
 
     def needs_reproject(self):
         '''returns True if the crate needs to project between source and destination
@@ -389,7 +389,7 @@ class Crate(object):
         if self.destination_coordinate_system is None:
             needs_reproject = False
         else:
-            needs_reproject = self.destination_coordinate_system.name != self.source_describe.spatialReference.name
+            needs_reproject = self.destination_coordinate_system.name != self.source_describe['spatialReference'].name
 
         return needs_reproject
 


### PR DESCRIPTION
Closes #255

### Test results and coverage

```
----------- coverage: platform win32, python 3.6.8-final-0 -----------
Name                                                                                                  Stmts   Miss Branch BrPart     Cover
  Missing
----------------------------------------------------------------------------------------------------------------------------------------------------
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\__main__.py       71     71     42      0     0.00%
  3-189
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\arcgis.py        113     29     32      2    70.34%
  26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224, 178->181, 197->198
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\config.py         50      1     20      2    95.71%
  82, 81->82, 117->116
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\core.py          186      5     72      3    96.12%
  122, 145-146, 345, 415, 121->122, 292->291, 414->415
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\engine.py        428    147    142     11    63.86%
  133, 202, 215, 228-303, 317-319, 369-440, 470, 480, 486-496, 501-514, 530, 550, 569, 582-585, 645-646, 651, 665-671, 677, 684, 730, 835-875, 130->133, 214->215, 227->228, 307->341, 316->317, 529->530, 568->569, 642->645, 648->651, 681->684, 729->730
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\lift.py          145     51     52      4    60.91%
  39, 149-152, 159-160, 183-194, 229-250, 277, 281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\messaging.py      39      1      6      0    97.78%
  55
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\models.py        192      4     56      3    96.37%
  89, 392, 444-445, 176->175, 389->392, 436->444
----------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                  1246    309    428     25    72.40%

3 files skipped due to complete coverage.

=================== 181 passed, 63 skipped, 5 warnings in 458.35 seconds ====================
```

### Speed test results

```
(forklift) λ python -m forklift speedtest
Setting up speed test...
Tests ready starting dry run...
Changing data...
Repeating test...
Dry Run Output


    5 out of 5 pallets ran successfully in 2.65 minutes.
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPallet (72.93 seconds)
                           AddressPoints - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPalletNoReproject (56.98 seconds)
                  AddressPointsNoProject - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:ShapefilePallet (9735 ms)
                   CountiesFromShapefile - Created table successfully.
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:SmallDataPallet (7449 ms)
                                Counties - Created table successfully.
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:TablePallet (8350 ms)
                              SchoolInfo - Created table successfully.

Repeat Run Output


    5 out of 5 pallets ran successfully in 1.66 minutes.
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPallet (10356 ms)
                           AddressPoints - Warning generated during update. Data not modified.
crate message: duplicate features detected!
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPalletNoReproject (74.54 seconds)
                  AddressPointsNoProject - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:ShapefilePallet (2739 ms)
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:SmallDataPallet (4550 ms)
C:\Projects\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:TablePallet (4818 ms)


Speed Test Results
Dry Run: 2.65 minutes
Repeat: 1.66 minutes
```