### PR TITLE
Add packing slip to lift report email

### DIFF
--- a/samples/RunablePallet.py
+++ b/samples/RunablePallet.py
@@ -16,7 +16,7 @@ from forklift.models import Pallet
 
 
 class RunablePallet(Pallet):
-    def build(self):
+    def build(self, configuration):
         self.log.info('building pallet')
 
     def lift(self):
@@ -29,6 +29,6 @@ class RunablePallet(Pallet):
 if __name__ == '__main__':
     pallet = RunablePallet()
     pallet.configure_standalone_logging()
-    pallet.build()
+    pallet.build('Dev')
     pallet.lift()
     pallet.ship()

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -180,7 +180,7 @@ def global_exception_handler(ex_cls, ex, tb):
     log.error(error)
 
     log_file = join(dirname(config.config_location), 'forklift.log')
-    messaging.send_email(config.get_config_prop('notify'), 'Forklift Error', error, log_file)
+    messaging.send_email(config.get_config_prop('notify'), 'Forklift Error', error, [log_file])
 
 
 def _add_global_error_handler():

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -37,12 +37,12 @@ class SendEmail(unittest.TestCase):
         get_config_prop_mock.side_effect = true_side_effect
         messaging.send_emails_override = None
 
-        smtp = messaging.send_email(['one@utah.gov', 'two@utah.gov'], '', '', attachment='None')
+        smtp = messaging.send_email(['one@utah.gov', 'two@utah.gov'], '', '')
 
         # pylint: disable=no-member
         self.assertEqual(smtp.sendmail.call_args[0][1], ['one@utah.gov', 'two@utah.gov'])
 
-        smtp = messaging.send_email('one@utah.gov', '', '', attachment='None')
+        smtp = messaging.send_email('one@utah.gov', '', '')
 
         self.assertEqual(smtp.sendmail.call_args[0][1], 'one@utah.gov')
 
@@ -50,7 +50,7 @@ class SendEmail(unittest.TestCase):
         get_config_prop_mock.side_effect = true_side_effect
         messaging.send_emails_override = None
 
-        smtp = messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None')
+        smtp = messaging.send_email('hello@utah.gov', 'subject', 'body')
 
         # pylint: disable=no-member
         self.assertIn('Subject: subject', smtp.sendmail.call_args[0][2])
@@ -62,7 +62,7 @@ class SendEmail(unittest.TestCase):
         message.attach(MIMEText('<p>test</p>', 'html'))
         message.attach(MIMEText('test'))
 
-        smtp = messaging.send_email('hello@utah.gov', 'subject', message, attachment='None')
+        smtp = messaging.send_email('hello@utah.gov', 'subject', message)
 
         # pylint: disable=no-member
         self.assertIn('test', smtp.sendmail.call_args[0][2])
@@ -70,25 +70,25 @@ class SendEmail(unittest.TestCase):
     def test_send_emails_false(self, SMTP_mock, get_config_prop_mock):
         get_config_prop_mock.side_effect = false_side_effect
 
-        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None'))
+        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body'))
 
     def test_send_emails_override(self, SMTP_mock, get_config_prop_mock):
         get_config_prop_mock.side_effect = false_side_effect
         messaging.send_emails_override = False
 
-        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None'))
+        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body'))
 
         get_config_prop_mock.return_value = True
         messaging.send_emails_override = False
 
-        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None'))
+        self.assertIsNone(messaging.send_email('hello@utah.gov', 'subject', 'body'))
 
         get_config_prop_mock.return_value = True
         messaging.send_emails_override = True
 
-        self.assertIsNotNone(messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None'))
+        self.assertIsNotNone(messaging.send_email('hello@utah.gov', 'subject', 'body'))
 
         get_config_prop_mock.side_effect = false_side_effect
         messaging.send_emails_override = True
 
-        self.assertIsNotNone(messaging.send_email('hello@utah.gov', 'subject', 'body', attachment='None'))
+        self.assertIsNotNone(messaging.send_email('hello@utah.gov', 'subject', 'body'))


### PR DESCRIPTION
### Test results and coverage

```
Name                                                                                                  Stmts   Miss Branch BrPart     Cover
  Missing
----------------------------------------------------------------------------------------------------------------------------------------------------
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\__main__.py       71     71     42      0     0.00%
  3-189
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\arcgis.py        113     29     32      2    70.34%
  26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224, 178->181, 197->198
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\config.py         50      1     20      2    95.71%
  82, 81->82, 117->116
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\core.py          186      5     72      3    96.12%
  122, 145-146, 345, 415, 121->122, 292->291, 414->415
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\engine.py        428    147    142     11    63.86%
  133, 202, 215, 228-303, 317-319, 369-440, 470, 480, 486-496, 501-514, 530, 550, 569, 582-585, 645-646, 651, 665-671, 677, 684, 730, 835-875, 130->133, 214->215, 227->228, 307->341, 316->317, 529->530, 568->569, 642->645, 648->651, 681->684, 729->730
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\lift.py          145     51     52      4    60.91%
  39, 149-152, 159-160, 183-194, 229-250, 277, 281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\messaging.py      39      1      6      0    97.78%
  55
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\models.py        192      4     56      3    96.37%
  89, 392, 444-445, 176->175, 389->392, 436->444
----------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                  1246    309    428     25    72.40%

3 files skipped due to complete coverage.

========================================== 175 passed, 69 skipped, 5 warnings in 353.49 seconds ==========================================
```

### Speed test results

```
Name                                                                                                  Stmts   Miss Branch BrPart     Cover
  Missing
----------------------------------------------------------------------------------------------------------------------------------------------------
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\__main__.py       71     71     42      0     0.00%
  3-189
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\arcgis.py        113     29     32      2    70.34%
  26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224, 178->181, 197->198
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\config.py         50      1     20      2    95.71%
  82, 81->82, 117->116
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\core.py          186      5     72      3    96.12%
  122, 145-146, 345, 415, 121->122, 292->291, 414->415
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\engine.py        428    147    142     11    63.86%
  133, 202, 215, 228-303, 317-319, 369-440, 470, 480, 486-496, 501-514, 530, 550, 569, 582-585, 645-646, 651, 665-671, 677, 684, 730, 835-875, 130->133, 214->215, 227->228, 307->341, 316->317, 529->530, 568->569, 642->645, 648->651, 681->684, 729->730
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\lift.py          145     51     52      4    60.91%
  39, 149-152, 159-160, 183-194, 229-250, 277, 281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\messaging.py      39      1      6      0    97.78%
  55
C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\Lib\site-packages\forklift\models.py        192      4     56      3    96.37%
  89, 392, 444-445, 176->175, 389->392, 436->444
----------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                  1246    309    428     25    72.40%

3 files skipped due to complete coverage.

========================================== 175 passed, 69 skipped, 5 warnings in 353.49 seconds ==========================================
```
