### PR TITLE
Ship timer for report

### DIFF
--- a/samples/TypicalPallet.py
+++ b/samples/TypicalPallet.py
@@ -2,6 +2,7 @@
 # * coding: utf8 *
 
 from os import path
+from time import sleep
 
 from forklift.models import Pallet
 
@@ -23,3 +24,9 @@ class TypicalPallet(Pallet):
         source_workspace = path.join(data_folder, 'SourceData.gdb')
 
         self.add_crates(['Counties'], {'source_workspace': source_workspace, 'destination_workspace': self.boundaries_utm})
+
+    def ship(self):
+        sleep(1)
+
+    def post_copy_process(self):
+        sleep(1)

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -109,14 +109,14 @@ class Pallet(object):
         Given an array of strings or tuples this method will create and add a `Crate` to the `_crates` list.
 
         If a `crate_infos` index is a string, a `Crate` is created with the value as `source_name` and `destination_name`.
-        It is expected for `defaults` to contain `source_workspace` and `destination_workspace` vaules.
+        It is expected for `defaults` to contain `source_workspace` and `destination_workspace` values.
 
         If a `crate_infos` index is a tuple, the values are zipped with the `crate_param_names` list.
 
         If a tuple has 1 value, the value will be set to `source_name` and `destination_name`.
-        The `defaults` need to contain `source_workspace` and `destination_workspace` vaules.
+        The `defaults` need to contain `source_workspace` and `destination_workspace` values.
         If a tuple has 2 values, the first value is set to `source_name` and `destination_name`. The second value sets
-        the `source_workspace` and `defaults` needs to contain `destination_workspace`. `source_workspace` is overriden.
+        the `source_workspace` and `defaults` needs to contain `destination_workspace`. `source_workspace` is overridden.
         If a tuple has 3 values, the first value is set to `source_name` and `destination_name`. The second value sets
         the `source_workspace`. The third value sets `destination_workspace`. `defaults` is unused.
         If a tuple has 4 values, the first value is set to `source_name`. The second value sets `source_workspace`.
@@ -150,7 +150,7 @@ class Pallet(object):
 
         This method should return `True` if the crate is ready for an update. Otherwise it
         should raise `exceptions.ValidationException`.
-        If this method is not overriden the default validate method within core is used.
+        If this method is not overridden the default validate method within core is used.
         '''
         return NotImplemented
 
@@ -354,7 +354,7 @@ class Crate(object):
         return self.result
 
     def get_report(self):
-        '''Returns the relavant info related to this crate that is shown on the report as a dictionary
+        '''Returns the relevant info related to this crate that is shown on the report as a dictionary
         '''
         status = self.result[0]
         if status == self.NO_CHANGES:
@@ -442,7 +442,7 @@ class Crate(object):
             return (True, new_name)
 
         if len(names) > 1:
-            return (False, 'Duplcate names: {}'.format(','.join(names)))
+            return (False, 'Duplicate names: {}'.format(','.join(names)))
 
     def __repr__(self):
         '''Override for better logging. Use with %r


### PR DESCRIPTION
## Description of Changes

This pull requests fixes the report to show how long it took to ship a pallet. Prior the report was using the lift time.

### Test results and coverage
<!--
from ./
python setup.py develop && pytest
-->

```
----------- coverage: platform win32, python 3.6.5-final-0 -----------
Name                                        Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------------------------------------------
C:\dev\forklift\src\forklift\arcgis.py        113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224, 178->181, 197->198
C:\dev\forklift\src\forklift\config.py         50      1     20      2    95.71%   82, 81->82, 117->116
C:\dev\forklift\src\forklift\core.py          186      5     72      3    96.12%   122, 145-146, 345, 415, 121->122, 292->291, 414->415
C:\dev\forklift\src\forklift\engine.py        436    147    144     11    64.48%   133, 202, 215, 228-303, 318-320, 375-446, 476, 486, 492-502, 507-520, 536, 556, 575, 588-591, 661-662, 667, 681-687, 693, 700, 746, 851-891, 130->133, 214->215, 227->228, 307->347, 317->318, 535->536, 574->575, 658->661, 664->667, 697->700, 745->746
C:\dev\forklift\src\forklift\lift.py          145     51     52      4    60.91%   39, 149-152, 159-160, 183-194, 229-250, 277, 281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
C:\dev\forklift\src\forklift\messaging.py      43      2      8      1    94.12%   57, 78, 77->78
C:\dev\forklift\src\forklift\models.py        192      6     56      3    95.56%   89, 323-324, 392, 444-445, 176->175, 389->392, 436->444
------------------------------------------------------------------------------------------
TOTAL                                        1187    241    390     26    77.62%

3 files skipped due to complete coverage.


============= 2 failed, 152 passed, 90 skipped in 136.50 seconds ==============
```

The two failed tests are as follows and look like they are related to the `arcpy.da.describe` pr but didn't error for you so... i'm going to ignore them.

```
>           self.source_describe = describer(self.source)
E           ValueError: Object: Error in accessing describe

c:\dev\forklift\src\forklift\models.py:321: ValueError
```

### Speed test results
<!--
from ./src
python -m forklift speedtest
-->

```
forklift λ python -m forklift speedtest
Setting up speed test...
Tests ready starting dry run...
Changing data...
Repeating test...
Dry Run Output


    5 out of 5 pallets ran successfully in 1.95 minutes.
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPallet (59.99 seconds)
                           AddressPoints - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPalletNoReproject (40.52 seconds)
                  AddressPointsNoProject - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:ShapefilePallet (6677 ms)
                   CountiesFromShapefile - Created table successfully.
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:SmallDataPallet (4504 ms)
                                Counties - Created table successfully.
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:TablePallet (3882 ms)
                              SchoolInfo - Created table successfully.

Repeat Run Output


    5 out of 5 pallets ran successfully in 77.59 seconds.
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPallet (6305 ms)
                           AddressPoints - Warning generated during update. Data not modified.
crate message: duplicate features detected!
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:LargeDataPalletNoReproject (62.38 seconds)
                  AddressPointsNoProject - Warning generated during update and data updated successfully.
crate message: duplicate features detected!
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:ShapefilePallet (2171 ms)
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:SmallDataPallet (2561 ms)
C:\dev\forklift\src\forklift\..\..\speedtest\SpeedTestPallet.py:TablePallet (2586 ms)


Speed Test Results
Dry Run: 1.95 minutes
Repeat: 77.6 seconds
```
