### PR TITLE
Ship pallet report status

### DIFF
--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -891,7 +891,7 @@ def _generate_ship_console_report(pallet_reports):
         )
 
         if report['message']:
-            report_str += '  pallet message: {}{}{}{}'.format(Fore.RED, report['message'], Fore.RESET, linesep)
+            report_str += '  pallet message: {}{}{}{}'.format(color, report['message'], Fore.RESET, linesep)
 
     return report_str
 

--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -336,6 +336,11 @@ def ship_data(pallet_arg=None, by_service=False):
                         pallet.ship()
 
                     slip['shipped'] = True
+
+                #: update pallet result for report in case the result was set
+                #: during post_copy_process or ship
+                slip['success'] = pallet.result[0]
+                slip['message'] += pallet.result[1]
             except Exception as e:
                 slip['success'] = False
                 slip['message'] = e

--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -319,7 +319,7 @@ class Crate(object):
 
         try:
             self.source_describe = describer(self.source)
-        except IOError as e:
+        except Exception as e:
             self.result = (Crate.INVALID_DATA, e)
             return
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -489,7 +489,7 @@ class TestShipData(CleanUpAlternativeConfig):
     @patch('forklift.engine.listdir', return_value=[engine.packing_slip_file])
     def test_post_process_if_success(self, listdir, copy_data, packing_slip, exists, generate_mock):
         slip = {'success': True, 'requires_processing': True}
-        pallet = Mock(slip=slip)
+        pallet = Mock(slip=slip, total_processing_time=3)
         pallet.ship.return_value = None
         pallet.post_copy_process.return_value = None
         pallet.copy_data = []
@@ -507,7 +507,7 @@ class TestShipData(CleanUpAlternativeConfig):
     @patch('forklift.engine.listdir', return_value=[engine.packing_slip_file])
     def test_post_process_if_not_success(self, listdir, copy_data, packing_slip, exists, generate_mock):
         slip = {'success': False, 'requires_processing': True}
-        pallet = Mock(slip=slip)
+        pallet = Mock(slip=slip, total_processing_time=3)
         pallet.ship.return_value = None
         pallet.post_copy_process.return_value = None
         pallet.copy_data = []


### PR DESCRIPTION
## Description of Changes
This pull request fixes a bug that was overwriting the manually set pallet result with the associated packing slip pallet result causing false positives.

### Test results and coverage
```
====================================== test session starts ======================================
platform win32 -- Python 3.6.8, pytest-4.6.5, py-1.8.0, pluggy-0.13.0
rootdir: C:\Projects\forklift, inifile: pytest.ini
plugins: cov-2.7.1, instafail-0.4.1, isort-0.3.1, pylint-0.14.1
collected 244 items                                                                              
-----------------------------------------------------------------
Linting files
.
-----------------------------------------------------------------

setup.py ss                                                                             [  2/244]
samples\PalletSamples.py ss                                                             [  4/244]
samples\RunablePallet.py ss                                                             [  6/244]
samples\TypicalPallet.py ss                                                             [  8/244]
speedtest\SpeedTestPallet.py ss                                                         [ 10/244]
src\forklift\__init__.py ss                                                             [ 12/244]
src\forklift\__main__.py ss                                                             [ 14/244]
src\forklift\arcgis.py ss                                                               [ 16/244]
src\forklift\config.py ss                                                               [ 18/244]
src\forklift\core.py ss                                                                 [ 20/244]
src\forklift\engine.py ss                                                               [ 22/244]
src\forklift\exceptions.py ss                                                           [ 24/244]
src\forklift\lift.py ss                                                                 [ 26/244]
src\forklift\messaging.py ss                                                            [ 28/244]
src\forklift\models.py ..                                                               [ 30/244]
src\forklift\seat.py ss                                                                 [ 32/244]
tests\__init__.py ss                                                                    [ 34/244]
tests\PalletWithSyntaxErrors.py ss                                                      [ 36/244]
tests\SchemaLockPallet.py ss                                                            [ 38/244]
tests\benchmark_arcgis.py ss                                                            [ 40/244]
tests\conftest.py ss                                                                    [ 42/244]
tests\mocks.py ss                                                                       [ 44/244]
tests\test_arcgis.py ss.................                                                [ 63/244]
tests\test_changes.py ss......                                                          [ 71/244]
tests\test_config.py ss......                                                           [ 79/244]
tests\test_core.py ss.................................                                  [114/244]
tests\test_crate.py ss...................                                               [135/244]
tests\test_engine.py ss......................s..........                                [170/244]
tests\test_lift.py ss.........                                                          [181/244]
tests\test_messaging.py ss.....                                                         [188/244]
tests\test_pallet.py ss..............................                                   [220/244]
tests\test_seat.py ss....                                                               [226/244]
tests\data\BuildErrorPallet.py ss                                                       [228/244]
tests\data\duplicate_import.py ss                                                       [230/244]
tests\data\pallet_argument.py ss                                                        [232/244]
tests\data\pallet_order.py ss                                                           [234/244]
tests\data\alphabetize\pallet.py ss                                                     [236/244]
tests\data\list_pallets\multiple_pallets.py ss                                          [238/244]
tests\data\list_pallets\not_a_pllet.py ss                                               [240/244]
tests\data\list_pallets\single_pallet.py ss                                             [242/244]
tests\data\list_pallets\nested\pallets\nestedPallet.py ss                               [244/244]

======================================= warnings summary ========================================
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
  c:\users\agrc-arcgis\appdata\local\esri\conda\envs\forklift\lib\importlib\_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform win32, python 3.6.8-final-0 -----------
Name                        Stmts   Miss Branch BrPart     Cover   Missing
--------------------------------------------------------------------------
src\forklift\arcgis.py        113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146,
163, 181, 198-200, 222-224, 178->181, 197->198
src\forklift\config.py         50      1     20      2    95.71%   82, 81->82, 117->116
src\forklift\core.py          186      5     72      3    96.12%   122, 145-146, 345, 415, 121->122, 292->291, 414->415
src\forklift\engine.py        438    148    144     11    64.43%   133, 202, 215, 228-303, 318-320, 343, 380-451, 481, 491, 497-507, 512-525, 541, 561, 580, 593-596, 666-667, 672, 686-692, 698, 705, 751, 856-896, 130->133, 214->215, 227->228, 307->352, 317->318, 540->541, 579->580, 663->666, 669->672, 702->705, 750->751
src\forklift\lift.py          145     51     52      4    60.91%   39, 149-152, 159-160, 183-194,
229-250, 277, 281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
src\forklift\messaging.py      43      2      8      1    94.12%   57, 78, 77->78
src\forklift\models.py        192      4     56      3    96.37%   89, 392, 444-445, 176->175, 389->392, 436->444
--------------------------------------------------------------------------
TOTAL                        1189    240    390     26    77.71%

3 files skipped due to complete coverage.

===================== 163 passed, 81 skipped, 5 warnings in 351.63 seconds ======================
```

### Speed test results
```
Speed Test Results
Dry Run: 2.58 minutes
Repeat: 1.52 minutes
```
