### PR TITLE
Add pallet argument to `gift-wrap`

### DIFF
--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -15,7 +15,7 @@ Usage:
     forklift ship [--verbose] [--pallet-arg <arg>] [--skip-emails|--send-emails] [--by-service]
     forklift list-pallets
     forklift scorched-earth
-    forklift gift-wrap --output <folder-path> [--input <fgdb-path>]
+    forklift gift-wrap --output <folder-path> [--input <fgdb-path>|--pallet <file-path>] [--verbose]
     forklift speedtest
     forklift special-delivery <file-path> [--pallet-arg <arg>] [--verbose]
 
@@ -50,6 +50,7 @@ Examples:
                                                                             `hashes.gdb` & `scratch.gdb` file geodatabases.
     forklift gift-wrap --output path/to/folder                              Gift wraps everything in `config.hashLocation`
     forklift gift-wrap --output path/to/folder --input path/to/fgdb.gdb     Gift wraps `path\to\fgdb.gdb`
+    forklift gift-wrap --output path/to/folder --pallet pallet_file.py      Gift wraps all data (as defined by `copy_data`) in pallets defined in pallet_file.py
     forklift speedtest                                                      Test the speed on a predefined pallet.
     forklift special-delivery path/to/pallet_file.py                        Lifts and ships a single file's worth of pallets without messing with
                                                                             any existing data in `dropoffLocation`. During shipping, it also shuts
@@ -136,7 +137,7 @@ def main():
     elif args['scorched-earth']:
         engine.scorched_earth()
     elif args['gift-wrap']:
-        engine.gift_wrap(args['<folder-path>'], args['<fgdb-path>'])
+        engine.gift_wrap(args['<folder-path>'], args['<fgdb-path>'], args['<file-path>'])
     elif args['speedtest']:
         engine.speedtest(speedtest)
     elif args['special-delivery']:

--- a/src/forklift/__main__.py
+++ b/src/forklift/__main__.py
@@ -15,44 +15,47 @@ Usage:
     forklift ship [--verbose] [--pallet-arg <arg>] [--skip-emails|--send-emails] [--by-service]
     forklift list-pallets
     forklift scorched-earth
-    forklift gift-wrap --output <file-path> [--input <file-path2>]
+    forklift gift-wrap --output <folder-path> [--input <fgdb-path>]
     forklift speedtest
     forklift special-delivery <file-path> [--pallet-arg <arg>] [--verbose]
 
 Arguments:
     repo            The name of a GitHub repository in <owner>/<name> format.
     file-path       A path to a file that defines one or multiple pallets.
+    fgdb-path       A path to a file geodatabase.
+    folder-path     A path to a folder.
     pallet-arg      A string to be used as an optional initialization parameter to the pallet.
 
 Examples:
-    forklift config init                                    Creates the config file.
-    forklift config repos --add agrc/ugs-chemistry          Adds a path to the config. Checks for duplicates.
-    forklift config repos --list                            Outputs the list of pallet folder paths in your config file.
-    forklift config repos --remove agrc/ugs-chemistry       Removes a path from the config.
-    forklift config set --key <key> --value <value>         Sets a key in the config with a value.
-    forklift garage open                                    Opens the garage folder with explorer.
-    forklift git-update                                     Pulls the latest updates to all git repositories.
-    forklift lift                                           The main entry for running all of pallets found in the warehouse folder.
-    forklift lift --verbose                                 Print DEBUG statements to the console.
-    forklift lift --skip-emails                             Skip sending emails. Overrides `sendEmails` config as False.
-    forklift lift --send-emails                             Force sending emails. Overrides `sendEmails` config as True.
-    forklift lift path/to/pallet_file.py                    Run a specific pallet.
-    forklift lift path/to/pallet_file.py --pallet-arg arg   Run a specific pallet with "arg" as an initialization parameter.
-    forklift lift --preserve-drop-off-data                  Does not clear out existing data in `dropoffLocation`. [not yet implemented]
-    forklift ship                                           Moves data from the drop off location to the ship to location.
-    forklift ship --by-service path/to/pallet_file.py       Shuts down only those services that are related to the data that was changed
-                                                            related to the pallet(s) in the passed in file rather than shutting down the
-                                                            entire server before pushing data. [not yet implemented]
-    forklift list-pallets                                   Outputs the list of pallets from the config.
-    forklift scorched-earth                                 WARNING!!! Deletes all data in `config.stagingDestination` as well as the
-                                                            `hashes.gdb` & `scratch.gdb` file geodatabases.
-    forklift gift-wrap --output path/to/folder              Gift wraps everything in `config.hashLocation`
-    forklift speedtest                                      Test the speed on a predefined pallet.
-    forklift special-delivery path/to/pallet_file.py        Lifts and ships a single file's worth of pallets without messing with
-                                                            any existing data in `dropoffLocation`. During shipping, it also shuts
-                                                            down only the services that use the data that was updated rather than
-                                                            the entire ArcGIS Server instance. Note: this will only work for pallets
-                                                            that are in the warehouse.
+    forklift config init                                                    Creates the config file.
+    forklift config repos --add agrc/ugs-chemistry                          Adds a path to the config. Checks for duplicates.
+    forklift config repos --list                                            Outputs the list of pallet folder paths in your config file.
+    forklift config repos --remove agrc/ugs-chemistry                       Removes a path from the config.
+    forklift config set --key <key> --value <value>                         Sets a key in the config with a value.
+    forklift garage open                                                    Opens the garage folder with explorer.
+    forklift git-update                                                     Pulls the latest updates to all git repositories.
+    forklift lift                                                           The main entry for running all of pallets found in the warehouse folder.
+    forklift lift --verbose                                                 Print DEBUG statements to the console.
+    forklift lift --skip-emails                                             Skip sending emails. Overrides `sendEmails` config as False.
+    forklift lift --send-emails                                             Force sending emails. Overrides `sendEmails` config as True.
+    forklift lift path/to/pallet_file.py                                    Run a specific pallet.
+    forklift lift path/to/pallet_file.py --pallet-arg arg                   Run a specific pallet with "arg" as an initialization parameter.
+    forklift lift --preserve-drop-off-data                                  Does not clear out existing data in `dropoffLocation`. [not yet implemented]
+    forklift ship                                                           Moves data from the drop off location to the ship to location.
+    forklift ship --by-service path/to/pallet_file.py                       Shuts down only those services that are related to the data that was changed
+                                                                            related to the pallet(s) in the passed in file rather than shutting down the
+                                                                            entire server before pushing data. [not yet implemented]
+    forklift list-pallets                                                   Outputs the list of pallets from the config.
+    forklift scorched-earth                                                 WARNING!!! Deletes all data in `config.stagingDestination` as well as the
+                                                                            `hashes.gdb` & `scratch.gdb` file geodatabases.
+    forklift gift-wrap --output path/to/folder                              Gift wraps everything in `config.hashLocation`
+    forklift gift-wrap --output path/to/folder --input path/to/fgdb.gdb     Gift wraps `path\to\fgdb.gdb`
+    forklift speedtest                                                      Test the speed on a predefined pallet.
+    forklift special-delivery path/to/pallet_file.py                        Lifts and ships a single file's worth of pallets without messing with
+                                                                            any existing data in `dropoffLocation`. During shipping, it also shuts
+                                                                            down only the services that use the data that was updated rather than
+                                                                            the entire ArcGIS Server instance. Note: this will only work for pallets
+                                                                            that are in the warehouse.
 '''
 
 import faulthandler
@@ -133,7 +136,7 @@ def main():
     elif args['scorched-earth']:
         engine.scorched_earth()
     elif args['gift-wrap']:
-        engine.gift_wrap(args['<file-path>'], args['<file-path2>'])
+        engine.gift_wrap(args['<folder-path>'], args['<fgdb-path>'])
     elif args['speedtest']:
         engine.speedtest(speedtest)
     elif args['special-delivery']:

--- a/src/forklift/lift.py
+++ b/src/forklift/lift.py
@@ -218,7 +218,7 @@ def get_lift_status(pallets, elapsed_time, git_errors, import_errors):
     }
 
 
-def _copy_with_overwrite(source, destination):
+def copy_with_overwrite(source, destination):
     '''
     source: string - path to folder
     destination: string - path to folder
@@ -303,7 +303,7 @@ def copy_data(from_location, to_template, packing_slip_file, machine_name=None):
                 temp_path = destination_path + 'x'
                 if path.exists(destination_path) and path.exists(temp_path):
                     log.debug('cleaning up %s', destination_path)
-                    _copy_with_overwrite(temp_path, destination_path)
+                    copy_with_overwrite(temp_path, destination_path)
                     if path.isfile(temp_path):
                         remove(temp_path)
                     else:


### PR DESCRIPTION
## Description of Changes
This pull request adds a new optional argument to the `gift-wrap` command. It also tweaks it's behavior a bit in an attempt to make it a more smooth experience when using it to gift wrap data directly into receiving.

### Test results and coverage
```
============================================= test session starts =============================================
platform win32 -- Python 3.6.8, pytest-4.6.5, py-1.8.0, pluggy-0.13.0
rootdir: W:\forklift, inifile: pytest.ini
plugins: cov-2.7.1, instafail-0.4.1, isort-0.3.1, pylint-0.14.1
collected 244 items                                                                                            
-----------------------------------------------------------------
Linting files
........................................
-----------------------------------------------------------------

setup.py ..                                                                                           [  2/244]
samples\PalletSamples.py ..                                                                           [  4/244]
samples\RunablePallet.py ..                                                                           [  6/244]
samples\TypicalPallet.py ..                                                                           [  8/244]
speedtest\SpeedTestPallet.py ..                                                                       [ 10/244]
src\forklift\__init__.py ..                                                                           [ 12/244]
src\forklift\__main__.py ..                                                                           [ 14/244]
src\forklift\arcgis.py ..                                                                             [ 16/244]
src\forklift\config.py ..                                                                             [ 18/244]
src\forklift\core.py ..                                                                               [ 20/244]
src\forklift\engine.py ..                                                                             [ 22/244]
src\forklift\exceptions.py ..                                                                         [ 24/244]
src\forklift\lift.py ..                                                                               [ 26/244]
src\forklift\messaging.py ..                                                                          [ 28/244]
src\forklift\models.py ..                                                                             [ 30/244]
src\forklift\seat.py ..                                                                               [ 32/244]
tests\__init__.py ..                                                                                  [ 34/244]
tests\PalletWithSyntaxErrors.py ..                                                                    [ 36/244]
tests\SchemaLockPallet.py ..                                                                          [ 38/244]
tests\benchmark_arcgis.py ..                                                                          [ 40/244]
tests\conftest.py ..                                                                                  [ 42/244]
tests\mocks.py ..                                                                                     [ 44/244]
tests\test_arcgis.py ...................                                                              [ 63/244]
tests\test_changes.py ........                                                                        [ 71/244]
tests\test_config.py ........                                                                         [ 79/244]
tests\test_core.py ...................................                                                [114/244]
tests\test_crate.py .....................                                                             [135/244]
tests\test_engine.py ........................s..........                                              [170/244]
tests\test_lift.py ...........                                                                        [181/244]
tests\test_messaging.py .......                                                                       [188/244]
tests\test_pallet.py ................................                                                 [220/244]
tests\test_seat.py ......                                                                             [226/244]
tests\data\BuildErrorPallet.py ..                                                                     [228/244]
tests\data\duplicate_import.py ..                                                                     [230/244]
tests\data\pallet_argument.py ..                                                                      [232/244]
tests\data\pallet_order.py ..                                                                         [234/244]
tests\data\alphabetize\pallet.py ..                                                                   [236/244]
tests\data\list_pallets\multiple_pallets.py ..                                                        [238/244]
tests\data\list_pallets\not_a_pllet.py ..                                                             [240/244]
tests\data\list_pallets\single_pallet.py ..                                                           [242/244]
tests\data\list_pallets\nested\pallets\nestedPallet.py ..                                             [244/244]

============================================== warnings summary ===============================================
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
  c:\users\agrc-arcgis\appdata\local\esri\conda\envs\forklift\lib\importlib\_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform win32, python 3.6.8-final-0 -----------
Name                        Stmts   Miss Branch BrPart     Cover   Missing
--------------------------------------------------------------------------
src\forklift\arcgis.py        113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224, 178->181, 197->198
src\forklift\config.py         50      1     20      2    95.71%   82, 81->82, 117->116
src\forklift\core.py          186      5     72      3    96.12%   122, 145-146, 345, 415, 121->122, 292->291, 414->415
src\forklift\engine.py        447    157    154     11    62.40%   133, 202, 215, 228-303, 318-320, 343-344, 381-452, 482, 492, 506-525, 530-543, 559, 579, 598, 611-614, 684-685, 690, 704-710, 716, 723, 769, 874-914, 130->133, 214->215, 227->228, 307->353, 317->318, 558->559, 597->598, 681->684, 687->690, 720->723, 768->769
src\forklift\lift.py          145     51     52      4    60.91%   39, 149-152, 159-160, 183-194, 229-250, 277,
281, 288-291, 306-313, 342-353, 38->39, 148->149, 155->159, 280->281
src\forklift\messaging.py      43      2      8      1    94.12%   57, 78, 77->78
src\forklift\models.py        192      4     56      3    96.37%   89, 392, 444-445, 176->175, 389->392, 436->444
--------------------------------------------------------------------------
TOTAL                        1198    249    400     26    76.78%

3 files skipped due to complete coverage.

============================ 243 passed, 1 skipped, 5 warnings in 2118.69 seconds =============================
```