### PR TITLE
fix: remove the creation of "gift-wrapped" subfolder

### DIFF
--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -505,9 +505,6 @@ def gift_wrap(destination, source=None, pallet_path=None):
     Copies FGDBs from source or as defined by copy_data in pallet or in hashing directory
     and then scrubs the forklift hash field from them
     '''
-    if exists(destination):
-        destination = join(destination, 'gift-wrapped')
-
     sources = []
     if pallet_path is not None:
         pallets, _ = _build_pallets(pallet_path)


### PR DESCRIPTION
I don't believe that this is needed now that gift-wrap uses `lift.copy_with_overwrite`. This will save the user from having to manually copy the data after running the command.