### PR TITLE
feat: add ability to ignore changes in requires processing

### DIFF
--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -164,12 +164,14 @@ class Pallet(object):
         '''
         return self.are_crates_valid() and self.success[0]
 
-    def requires_processing(self):
-        '''Returns True if any crates were updated. Returns False if there are no crates defined.
+    def requires_processing(self, ignore_errors=False):
+        '''ignore_errors: Boolean
+
+        Returns True if any crates were updated. Returns False if there are no crates defined.
 
         returns: Boolean
         '''
-        if not self.are_crates_valid():
+        if not ignore_errors and not self.are_crates_valid():
             return False
 
         for crate in self._crates:

--- a/tests/test_pallet.py
+++ b/tests/test_pallet.py
@@ -283,6 +283,17 @@ class TestPallet(unittest.TestCase):
 
         self.assertFalse(self.patient.requires_processing())
 
+    def test_requires_processing_crates_ingore_errors(self):
+        updated = Crate('', '', '', '')
+        updated.result = (Crate.UPDATED, None)
+
+        unhandled_exception = Crate('', '', '', '')
+        unhandled_exception.result = (Crate.UNHANDLED_EXCEPTION, None)
+
+        self.patient._crates = [updated, updated, unhandled_exception]
+
+        self.assertTrue(self.patient.requires_processing(ignore_errors=True))
+
     def test_not_implemented(self):
         self.assertEqual(self.patient.process(), NotImplemented)
         self.assertEqual(self.patient.ship(), NotImplemented)


### PR DESCRIPTION
## Description of Changes
Some pallets (e.g. AGOLPallet) want processing to happen despite there being errors in some datasets. This PR adds an optional argument to `Pallet.requires_processing` that allows you to ignore the errors.

### Test results and coverage
```
=============================== test session starts ================================
platform win32 -- Python 3.6.9, pytest-4.6.5, py-1.8.0, pluggy-0.12.0
rootdir: W:\forklift, inifile: pytest.ini
plugins: cov-2.7.1, instafail-0.4.1.post0, isort-0.3.1, pylint-0.14.1
collected 245 items                                                                 
-----------------------------------------------------------------
Linting files
.
-----------------------------------------------------------------

setup.py ss                                                                [  2/245]
samples\PalletSamples.py ss                                                [  4/245]
samples\RunablePallet.py ss                                                [  6/245]
samples\TypicalPallet.py ss                                                [  8/245]
speedtest\SpeedTestPallet.py ss                                            [ 10/245]
src\forklift\__init__.py ss                                                [ 12/245]
src\forklift\__main__.py ss                                                [ 14/245]
src\forklift\arcgis.py ss                                                  [ 16/245]
src\forklift\config.py ss                                                  [ 18/245]
src\forklift\core.py ss                                                    [ 20/245]
src\forklift\engine.py ss                                                  [ 22/245]
src\forklift\exceptions.py ss                                              [ 24/245]
src\forklift\lift.py ss                                                    [ 26/245]
src\forklift\messaging.py ss                                               [ 28/245]
src\forklift\models.py ..                                                  [ 30/245]
src\forklift\seat.py ss                                                    [ 32/245]
tests\__init__.py ss                                                       [ 34/245]
tests\PalletWithSyntaxErrors.py ss                                         [ 36/245]
tests\SchemaLockPallet.py ss                                               [ 38/245]
tests\benchmark_arcgis.py ss                                               [ 40/245]
tests\conftest.py ss                                                       [ 42/245]
tests\mocks.py ss                                                          [ 44/245]
tests\test_arcgis.py ss.................                                   [ 63/245]
tests\test_changes.py ss......                                             [ 71/245]
tests\test_config.py ss......                                              [ 79/245]
tests\test_core.py ss.................................                     [114/245]
tests\test_crate.py ss...................                                  [135/245]
tests\test_engine.py ss......................s..........                   [170/245]
tests\test_lift.py ss.........                                             [181/245]
tests\test_messaging.py ss.....                                            [188/245]
tests\test_pallet.py ss...............................                     [221/245]
tests\test_seat.py ss....                                                  [227/245]
tests\data\BuildErrorPallet.py ss                                          [229/245]
tests\data\duplicate_import.py ss                                          [231/245]
tests\data\pallet_argument.py ss                                           [233/245]
tests\data\pallet_order.py ss                                              [235/245]
tests\data\alphabetize\pallet.py ss                                        [237/245]
tests\data\list_pallets\multiple_pallets.py ss                             [239/245]
tests\data\list_pallets\not_a_pllet.py ss                                  [241/245]
tests\data\list_pallets\single_pallet.py ss                                [243/245]
tests\data\list_pallets\nested\pallets\nestedPallet.py ss                  [245/245]

================================= warnings summary =================================
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
tests/test_core.py::CoreTests::test_check_counts
  C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\importlib\_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform win32, python 3.6.9-final-0 -----------
Name                        Stmts   Miss Branch BrPart     Cover   Missing
--------------------------------------------------------------------------
src\forklift\arcgis.py        113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146, 163, 178->181, 181, 197->198, 198-200, 222-224
src\forklift\config.py         50      1     20      2    95.71%   81->82, 82, 117->116
src\forklift\core.py          186      5     72      3    96.12%   121->122, 122, 145-146, 292->291, 345, 414->415, 415
src\forklift\engine.py        447    157    152     11    62.60%   130->133, 133, 202, 214->215, 215, 227->228, 228-305, 309->355, 319->320, 320-322, 345-346, 383-454, 484, 494, 508-524, 529-542, 557->558, 558, 578, 596->597, 597, 610-613, 680->683, 683-684, 686->689, 689, 703-709, 715, 719->722, 722, 767->768, 768, 873-913
src\forklift\lift.py          145     51     52      4    60.91%   38->39, 39, 148->149, 149-152, 155->159, 159-160, 183-194, 229-250, 277, 280->281, 281, 288-291, 306-313, 342-353
src\forklift\messaging.py      43      2      8      1    94.12%   57, 77->78, 78
src\forklift\models.py        192      4     56      3    96.37%   89, 178->177, 391->394, 394, 438->446, 446-447
--------------------------------------------------------------------------
TOTAL                        1198    249    398     26    76.88%

3 files skipped due to complete coverage.

============== 164 passed, 81 skipped, 5 warnings in 2864.18 seconds ===============
```