### PR TITLE
fix: handle mis-matching crates between pallet and packing list

### DIFF
--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -235,7 +235,11 @@ class Pallet(object):
 
         crate_objects_by_name = {crate.destination_name: crate for crate in self.get_crates()}
         for slip_crate in slip['crates']:
-            crate_objects_by_name[slip_crate['name']].result = [slip_crate['result']]
+            try:
+                crate_objects_by_name[slip_crate['name']].result = [slip_crate['result']]
+            except KeyError:
+                #: if the crate is not in the packing list, leave it uninitialized
+                pass
 
     def configure_standalone_logging(self, level=logging.INFO):
         '''set up logger for running the pallet as a standalone script outside of the forklift process

--- a/tests/test_pallet.py
+++ b/tests/test_pallet.py
@@ -380,3 +380,34 @@ class TestPalletAddPackingSlip(unittest.TestCase):
 
         self.assertTrue(pallet.get_crates()[1].was_updated())
         self.assertEqual(pallet.get_crates()[1].result[0], Crate.UPDATED)
+
+    def test_missing_crate(self):
+        slip = {
+            "name": "c:\\forklift\\warehouse\\warehouse\\sgid\\AGOLPallet.py:AGOLPallet",
+            "success": True,
+            "is_ready_to_ship": True,
+            "requires_processing": True,
+            "message": "",
+            "crates": [
+                {
+                    "name": "fc5",
+                    "result": "Data updated successfully.",
+                    "crate_message": "",
+                    "message_level": "",
+                    "source": "C:\\\\forklift-garage\\sgid10.sde\\SGID10.BOUNDARIES.ZipCodes",
+                    "destination": "\\\\123.456.789.123\\agrc\\sgid_to_agol\\sgid10mercator.gdb\\ZipCodes",
+                    "was_updated": True
+                }
+            ],
+            "total_processing_time": "55.06 seconds"
+        }
+        pallet = Pallet()
+        pallet.add_crates(['fc4', 'fc6'], {
+            'source_workspace': 'Z:\\a\\path\\to\\database.sde',
+            'destination_workspace': 'Z:\\a\\path\\to\\database.gdb'
+        })
+
+        pallet.add_packing_slip(slip)
+
+        #: this is basically here to make sure that add_packing_slip doesn't throw an exception
+        self.assertFalse(pallet.get_crates()[1].was_updated())


### PR DESCRIPTION
## Description of Changes
This pull request handles the situation where there are mis-matching crates between a built pallet (during ship) and the packing slip.

### Test results and coverage
<!--
from ./
python setup.py develop && pytest
-->

```
(forklift) λ pytest -k test_pallet.py
========================== test session starts ===========================
platform win32 -- Python 3.6.9, pytest-4.6.5, py-1.8.0, pluggy-0.12.0
rootdir: W:\forklift, inifile: pytest.ini
plugins: cov-2.7.1, instafail-0.4.1.post0, isort-0.3.1, pylint-0.14.1
collected 251 items / 218 deselected / 33 selected                        
-----------------------------------------------------------------
Linting files
.........
-----------------------------------------------------------------

tests\test_pallet.py .................................             [33/33]

----------- coverage: platform win32, python 3.6.9-final-0 -----------
Name                        Stmts   Miss Branch BrPart     Cover   Missing
--------------------------------------------------------------------------
src\forklift\arcgis.py        113     97     32      0    11.03%   20-50, 61-71, 79-107, 114-140, 143, 146, 156-163, 168-181, 186-187, 196-204, 209-218, 222-224
src\forklift\config.py         50     28     20      2    34.29%   65->66,
66, 77->80, 80-90, 103-128
src\forklift\core.py          186    161     72      0     9.69%   75-158,
166-249, 257-280, 288-295, 304-367, 377-380, 393, 408-421, 431-449
src\forklift\engine.py        469    415    160      0     8.59%   49-52, 62-67, 77-91, 99, 105-111, 132-183, 198-378, 390-461, 473-477, 487-503, 515-531, 536-549, 561-590, 601-607, 616-634, 646-660, 664-681, 698-737, 743, 747-750, 754, 766-776, 786-798, 810-846, 856-891, 901-944, 949-965
src\forklift\lift.py          145    122     52      0    11.68%   29-30, 38-41, 49-53, 63-69, 80-105, 114-133, 145-160, 168-173, 183-194, 208-210, 229-250, 264-319, 327-333, 342-353
src\forklift\messaging.py      53     39     16      0    20.29%   36-94, 100-112
src\forklift\models.py        196     45     56      7    74.60%   78, 83,
93, 180->179, 304->305, 305, 322->328, 324->328, 328-332, 339-343, 352-362, 371->372, 372, 389, 394-402, 427->429, 429, 441->444, 444-453, 467-473, 478, 483, 488, 495-497
src\forklift\seat.py           19      9      6      1    44.00%   18->21,
21-27, 35-36, 39, 42
src\forklift\slack.py         211    164    102      0    15.02%   23-31, 35-43, 49-123, 129-212, 229, 232, 236, 247, 250-255, 259-262, 265, 273-279,
282-290, 297-305, 308-311, 319, 322, 331-338, 341-344, 347-357, 360, 363-366, 372, 375
--------------------------------------------------------------------------
TOTAL                        1445   1080    516     10    20.65%

2 files skipped due to complete coverage.


============== 33 passed, 218 deselected in 127.84 seconds ===============
```