### PR TITLE
fix: make append more flexible with differing schemas

### DIFF
--- a/src/forklift/change_detection.py
+++ b/src/forklift/change_detection.py
@@ -71,7 +71,7 @@ class ChangeDetection(object):
         arcpy.management.TruncateTable(crate.destination)
 
         with arcpy.EnvManager(geographicTransformations=crate.geographic_transformation):
-            arcpy.management.Append(crate.source, crate.destination, 'TEST')
+            arcpy.management.Append(crate.source, crate.destination)
 
         table_name = crate.source_name.lower()
         with arcpy.da.UpdateCursor(self.hash_table, [hash_field], where_clause=f'{table_name_field} = \'{table_name}\'') as cursor:


### PR DESCRIPTION
This is causing issues with data that has additional fields added during processing. I don't believe that we need it since [we check the schemas of source and destination before this code runs](https://github.com/agrc/forklift/blob/d442f7b7d866527ab886fbd2db82e1afa7af7072/src/forklift/core.py#L90).

