### PR TITLE
fix: handle more database sources name formats

### DIFF
--- a/src/forklift/models.py
+++ b/src/forklift/models.py
@@ -432,7 +432,7 @@ class Crate(object):
                 names_cache[workspace] = names
 
             #: could get a value like db.owner.***name and db.owner.name so filter on name
-            return [fc for fc in names if fc.split('.')[2] == self.source_name]
+            return [fc for fc in names if fc.split('.')[-1] == self.source_name]
 
         names = filter_filenames(self.source_workspace, self.source_name)
 


### PR DESCRIPTION
This allows for database sources that have less than three parts when split by a ".".

Co-authored-by: steveoh <sgourley@utah.gov>

### Test results and coverage
<!--
from ./
python setup.py develop && pytest
-->

```
=========================================================================================== test session starts ============================================================================================
platform win32 -- Python 3.6.9, pytest-4.6.5, py-1.8.0, pluggy-0.12.0
rootdir: W:\forklift, inifile: pytest.ini, testpaths: tests
plugins: cov-2.7.1, instafail-0.4.1.post0, isort-0.3.1, pylint-0.14.1
collected 209 items                                                                                                                                                                                         
-----------------------------------------------------------------
Linting files
.
-----------------------------------------------------------------

tests\__init__.py ss                                                                                                                                                                               [  2/209]
tests\PalletWithSyntaxErrors.py ss                                                                                                                                                                 [  4/209]
tests\SchemaLockPallet.py ss                                                                                                                                                                       [  6/209]
tests\benchmark_arcgis.py ss                                                                                                                                                                       [  8/209]
tests\conftest.py ss                                                                                                                                                                               [ 10/209]
tests\mocks.py ss                                                                                                                                                                                  [ 12/209]
tests\test_arcgis.py ss.................                                                                                                                                                           [ 31/209]
tests\test_change_detection.py ss.......                                                                                                                                                           [ 40/209]
tests\test_changes.py ss......                                                                                                                                                                     [ 48/209]
tests\test_config.py ss......                                                                                                                                                                      [ 56/209]
tests\test_core.py ss.................................                                                                                                                                             [ 91/209]
tests\test_crate.py .....................                                                                                                                                                          [112/209]
tests\test_engine.py ss......................s..........                                                                                                                                           [147/209]
tests\test_lift.py ss.........                                                                                                                                                                     [158/209]
tests\test_messaging.py ss.....                                                                                                                                                                    [165/209]
tests\test_pallet.py ss................................                                                                                                                                            [199/209]
tests\test_seat.py ss....                                                                                                                                                                          [205/209]
tests\test_slack.py ss..                                                                                                                                                                           [209/209]

----------- coverage: platform win32, python 3.6.9-final-0 -----------
Name                               Stmts   Miss Branch BrPart     Cover   Missing
---------------------------------------------------------------------------------
src\forklift\arcgis.py               113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146, 163, 178->181, 181, 197->198, 198-200, 222-224
src\forklift\change_detection.py      56      5     12      2    89.71%   31-33, 50->51, 51, 53->54, 54
src\forklift\config.py                50      1     20      2    95.71%   82->83, 83, 118->117
src\forklift\core.py                 191      8     78      4    94.05%   96->97, 97-100, 129->130, 130, 153-154, 301->300, 354, 423->424, 424
src\forklift\engine.py               475    169    160     12    61.73%   133->136, 136, 155-156, 212, 224->225, 225, 237->238, 238-318, 322->368, 332->333, 333-335, 358-359, 397-468, 498, 508, 522-538, 543-556, 571->572, 572, 592, 610->611, 611, 624-627, 678->681, 681-688, 715->718, 718-719, 721->724, 724, 738-744, 750, 754->757, 757, 802->803, 803, 908-951
src\forklift\lift.py                 148     52     52      4    61.00%   34, 41->42, 42, 152->153, 153-156, 159->163, 163-164, 187-198, 233-254, 281, 284->285, 285, 292-295, 310-317, 346-357
src\forklift\messaging.py             53     10     16      1    72.46%   58, 78->79, 79, 100-112
src\forklift\models.py               194      7     54      3    95.16%   93, 180->179, 330-332, 397->400, 400, 442->450, 450-451
src\forklift\slack.py                211     33    102     33    75.72%   24->25, 25-27, 54->57, 57, 71->72, 72-77, 79->80, 80-85, 90->93, 100->101, 101, 102->103, 103, 104->105, 105, 111->114, 116->117, 117-118, 120->87, 134->137, 137, 151->184, 155->158, 160->161, 161-164, 165->168, 168->171, 174->177, 189->192, 195->197, 197->200, 202->205, 236, 259->260, 260, 265, 276->278, 278->279, 279, 284->287, 287->288, 288, 304->305, 305, 331->332, 332, 333->334, 334, 347->348, 348, 351->354, 354->357, 360, 372, 375
---------------------------------------------------------------------------------
TOTAL                               1513    314    532     63    75.70%

3 files skipped due to complete coverage.


================================================================================ 174 passed, 35 skipped in 2105.29 seconds =================================================================================

```

