### PR TITLE
fix: handle errors posting report to slack

### DIFF
--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -685,7 +685,10 @@ def _send_report_to_slack(status, operation):
     else:
         messages = ship_report_to_blocks(status)
 
-    send_to_slack(url, messages)
+    try:
+        send_to_slack(url, messages)
+    except Exception as exc:
+        log.error(f'Error posting report to slack: {exc}')
 
 
 def _clone_or_pull_repo(repo_name):


### PR DESCRIPTION
Prevent the entire forklift process from crashing if there's an issue posting the report to slack.