### PR TITLE
add sendgrid mail client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Interacting with forklift is done via the [command line interface](src/forklift/
   - `hash` - A string that represents a unique hash of the entirety of the data in the table such that any change to data in the table will result in a new value.
 - `configuration` - A configuration string (`Production`, `Staging`, or `Dev`) that is passed to `Pallet:build` to allow a pallet to use different settings based on how forklift is being run. Defaults to `Production`.
 - `dropoffLocation` - The folder location where production ready files will be placed. This data will be compressed and will not contain any forklift artifacts. Pallets place their data in this location within their `copy_data` property.
-- `email` - An object containing `fromAddress`, `smptPort`, and `smtpServer` for sending report emails.
+- `email` - An object containing `fromAddress`, and `smptPort`, and `smtpServer` or a sendgrid `apiKey` for sending report emails.
 - `hashLocation` - The folder location where forklift creates and manages data. This data contains hash digests that are used to check for changes. Referencing this location within a pallet is done by: `os.path.join(self.staging_rack, 'the.gdb')`.
 - `notify` - An array of emails that will be sent the summary report each time `forklift lift` is run.
 - `repositories` - A list of github repositories in the `<owner>/<name>` format that will be cloned/updated into the `warehouse` folder. A secure git repo can be added manually to the config in the format below:

--- a/readme.md
+++ b/readme.md
@@ -60,13 +60,13 @@ Interacting with forklift is done via the [command line interface](src/forklift/
 - `notify` - An array of emails that will be sent the summary report each time `forklift lift` is run.
 - `repositories` - A list of github repositories in the `<owner>/<name>` format that will be cloned/updated into the `warehouse` folder. A secure git repo can be added manually to the config in the format below:
 
-    ```json
-    "repositories": [{
-      "host": "gitlabs.com/",
-      "repo": "name/repo",
-      "token": "personal access token with `read_repository` access only"
-    }]
-    ```
+  ```json
+  "repositories": [{
+    "host": "gitlabs.com/",
+    "repo": "name/repo",
+    "token": "personal access token with `read_repository` access only"
+  }]
+  ```
 
 - `sendEmails` - A boolean value that determines whether or not to send forklift summary report emails after each lift.
 - `servers` - An object describing one or more production servers that data will be shipped to. See below for more information.
@@ -102,45 +102,47 @@ From within the [ArcGIS Pro conda environment](http://pro.arcgis.com/en/pro-app/
 1. `forklift garage open` - Opens garage directory. Copy all connection.sde files to the forklift garage.
 1. `forklift git-update` - Updates pallet repos. Add any secrets or supplementary data your pallets need that is not in source control.
 1. Edit the `config.json` to add the arcgis server(s) to manage. The options property will be mixed in to all of the other servers.
-    - `username` ArcGIS admin username.
-    - `password` ArcGIS admin password.
-    - `host` ArcGIS host address eg: `myserver`. Validate this property by looking at the `machineName` property returned by `/arcgis/admin/machines?f=json`
-    - `port` ArcGIS server instance port eg: 6080
 
-    ```json
-    "servers": {
-       "options": {
-           "username": "mapserv",
-           "password": "test",
-           "port": 6080
-       },
-       "primary": {
-           "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines",
-       },
-       "secondary": {
-           "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines"
-       },
-       "backup": {
-           "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines",
-           "username": "test",
-           "password": "password",
-           "port": 6443
-       }
-    }
-    ```
+   - `username` ArcGIS admin username.
+   - `password` ArcGIS admin password.
+   - `host` ArcGIS host address eg: `myserver`. Validate this property by looking at the `machineName` property returned by `/arcgis/admin/machines?f=json`
+   - `port` ArcGIS server instance port eg: 6080
+
+   ```json
+   "servers": {
+      "options": {
+          "username": "mapserv",
+          "password": "test",
+          "port": 6080
+      },
+      "primary": {
+          "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines",
+      },
+      "secondary": {
+          "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines"
+      },
+      "backup": {
+          "host": "this.is.the.qualified.name.as.seen.in.arcgis.server.machines",
+          "username": "test",
+          "password": "password",
+          "port": 6443
+      }
+   }
+   ```
 
 1. Edit the `config.json` to add the email notification properties. _(This is required for sending email reports)_
-    - `smtpServer` The SMTP server that you want to send emails with.
-    - `smtpPort` The SMTP port number.
-    - `fromAddress` The from email address for emails sent by forklift.
 
-    ```json
-    "email": {
-        "smtpServer": "smpt.server.address",
-        "smtpPort": 25,
-        "fromAddress": "noreply@utah.gov"
-    }
-    ```
+   - `smtpServer` The SMTP server that you want to send emails with.
+   - `smtpPort` The SMTP port number.
+   - `fromAddress` The from email address for emails sent by forklift.
+
+   ```json
+   "email": {
+       "smtpServer": "smpt.server.address",
+       "smtpPort": 25,
+       "fromAddress": "noreply@utah.gov"
+   }
+   ```
 
 1. `forklift lift`
 1. `forklift ship`
@@ -150,6 +152,7 @@ From within the [ArcGIS Pro conda environment](http://pro.arcgis.com/en/pro-app/
 ### Upgrading Forklift
 
 From the root of the forklift source code folder:
+
 1. Activate forklift environment: `activate forklift`
 1. Pull any new updates from GitHub: `git pull origin master`
 1. Pip install with the upgrade option: `pip install .\ -U`
@@ -313,7 +316,7 @@ If you have pip installed forklift into your current environment, you may need t
 - Added `ERROR` as a possible result type for crates.
 - Removed unused crate property, `source_primary_key`
 - BREAKING CHANGE: Split up lift and ship to be independent commands.
-  - Replaced arcgis server env variables with config.json properties to allow for managing a silo'd  architecture or multiple machines not in a cluster
+  - Replaced arcgis server env variables with config.json properties to allow for managing a silo'd architecture or multiple machines not in a cluster
   - Replaced env variables with config.json properties for consistency.
   - Ship now shuts down the entire ArcGIS Server machine rather than specific services. It also now does this one machine at time to minimize downtime.
   - Removed static data processing since it can now be accomplished by dropping the data into the dropoff folder.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     keywords=[],
     install_requires=[
         'colorama==0.*', 'docopt==0.6.*', 'gitpython==2.*', 'ndg-httpsclient==0.*', 'pyasn1==0.*', 'pyopenssl==17.*', 'pystache==0.*', 'requests>=2.20.0',
-        'xxhash==1.*'
+        'xxhash==1.*', 'sendgrid==6.*'
         #: pyopenssl, ndg-httpsclient, pyasn1 are there to disable ssl warnings in requests
     ],
     dependency_links=[],

--- a/src/forklift/config.py
+++ b/src/forklift/config.py
@@ -32,6 +32,7 @@ def create_default_config():
             'email': {
                 'smtpServer': 'send.state.ut.us',
                 'smtpPort': 25,
+                'apiKey': '',
                 'fromAddress': 'noreply@utah.gov'
             },
             'hashLocation': 'c:\\forklift\\data\\hashed',

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -9,10 +9,13 @@ A module that contains a method for sending emails
 import gzip
 import io
 import logging
+from base64 import b64encode
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail, Attachment, Disposition, FileContent, FileName, FileType
 from smtplib import SMTP
 
 import pkg_resources
@@ -54,7 +57,6 @@ def send_email(to, subject, body, attachments=[]):
     else:
         return _send_email_with_smtp(email_server, to, subject, body, attachments)
 
-
 def send_to_slack(url, messages):
     '''sends a message to the webhook url
     messages: the blocks to send to slack split at the maximum value of 50'''
@@ -72,6 +74,51 @@ def send_to_slack(url, messages):
 
         if response.status_code != 200:
             raise ValueError(f'Request to slack returned an error {response.status_code}, the response is: {response.text}')
+
+def _send_email_with_sendgrid(email_server, to, subject, body, attachments=[]):
+    '''
+    email_server: dict
+    to: string | string[]
+    subject: string
+    body: string | MIMEMultipart
+    attachments: string[] - paths to text files to attach to the email
+
+    Send an email.
+    '''
+    from_address = email_server['fromAddress']
+    api_key = email_server['apiKey']
+
+    if None in [from_address, api_key]:
+        log.warning('Required environment variables for sending emails do not exist. No emails sent. See README.md for more details.')
+
+        return
+
+    message = Mail(
+        from_email=from_address,
+        to_emails=to,
+        subject=subject,
+        html_content=body)
+
+    for path in attachments:
+        encoded_log = _gzip(path)
+
+        if encoded_log is None:
+            continue
+
+        content = b64encode(encoded_log).decode()
+
+        message.attachment = Attachment(
+            FileContent(content), FileName(f'{path.name}.gz'), FileType('x-gzip'), Disposition('attachment')
+        )
+
+    try:
+        client = SendGridAPIClient(api_key)
+
+        return client.send(message)
+    except Exception as e:
+        log.error(f'Error sending email with SendGrid: {e}')
+
+        return e
 
 def _send_email_with_smtp(email_server, to, subject, body, attachments=[]):
     '''

--- a/src/forklift/messaging.py
+++ b/src/forklift/messaging.py
@@ -52,7 +52,7 @@ def send_email(to, subject, body, attachments=[]):
 
     email_server = get_config_prop('email')
 
-    if 'apiKey' in email_server and email_server['apiKey'] is not None:
+    if 'apiKey' in email_server and email_server['apiKey'] is not None and email_server['apiKey'].strip() is not '':
         return _send_email_with_sendgrid(email_server, to, subject, body, attachments)
     else:
         return _send_email_with_smtp(email_server, to, subject, body, attachments)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -51,7 +51,8 @@ class TestConfigInit(CleanUpAlternativeConfig):
                     u'email': {
                         u'smtpServer': u'send.state.ut.us',
                         u'smtpPort': 25,
-                        u'fromAddress': u'noreply@utah.gov'
+                        u'apiKey': '',
+                        u'fromAddress': u'noreply@utah.gov',
                     },
                     u'hashLocation': u'c:\\forklift\\data\\hashed',
                     u'notify': [u'test@utah.gov'],


### PR DESCRIPTION
## Description of Changes

This pull requests uses send grid emailing if there is an api key in the config. I have an api key created already that we can use.

I believe this should work but I don't have forklift installed currently. Can we go through it together? I did test the mail sending code outside of the forklift project and that worked wonderfully.