### PR TITLE
fix: only run lift if ship process is successful

### DIFF
--- a/run_forklift_ship_lift.bat
+++ b/run_forklift_ship_lift.bat
@@ -1,3 +1,2 @@
 call activate forklift
-forklift ship --send-emails
-forklift lift --send-emails
+forklift ship --send-emails && forklift lift --send-emails


### PR DESCRIPTION
I believe that this will prevent the lift process from overwriting the staged data that may or may not have been copied to production if there was a global error during ship.