### PR TITLE
fix: handle null value for servers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 testpaths = tests
 norecursedirs = data maps
-log_print = False
 minversion = 3.5
 console_output_style = count
 addopts = --pylint --cov-branch --cov=forklift --instafail --isort

--- a/src/forklift/config.py
+++ b/src/forklift/config.py
@@ -80,6 +80,11 @@ def get_config_prop(key):
         return _get_config()[key]
 
     servers = _get_config()[key]
+
+    if servers is None or len(servers) == 0:
+        log.info('no servers defined in config')
+        return {}
+
     if 'options' not in servers.keys():
         return servers
 

--- a/src/forklift/engine.py
+++ b/src/forklift/engine.py
@@ -207,10 +207,6 @@ def ship_data(pallet_arg=None, by_service=False):
     #: look for servers in config
     servers = config.get_config_prop('servers')
 
-    if servers is None or len(servers) == 0:
-        log.info('no servers defined in config')
-        servers = []
-
     #: look for drop off location
     pickup_location = config.get_config_prop('dropoffLocation')
 

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -7,9 +7,9 @@ a module containing tests for the change detection module
 import logging
 from pathlib import Path
 
+import arcpy
 from pytest import raises
 
-import arcpy
 from forklift import core
 from forklift.change_detection import (ChangeDetection, _get_hashes,
                                        hash_field, table_name_field)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,3 +85,13 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(servers['1'], {'machineName': '1-host', 'username': 'username', 'password': 'password', 'port': 0})
 
         self.assertEqual(servers['2'], {'machineName': '2-host', 'username': 'other-username', 'password': 'other-password', 'port': 1})
+
+    @patch('forklift.config._get_config')
+    def test_config_values_null_servers(self, mock_obj):
+        mock_obj.return_value = {
+            'servers': None
+        }
+
+        servers = config.get_config_prop('servers')
+
+        self.assertEqual(servers, {})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,10 +11,10 @@ import unittest
 from os import path
 from pathlib import Path
 
+import arcpy
 import pytest
 from mock import MagicMock, Mock, patch
 
-import arcpy
 from forklift import core, engine
 from forklift.change_detection import ChangeDetection
 from forklift.exceptions import ValidationException

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -9,10 +9,10 @@ A module for testing crate.py
 import unittest
 from os import path
 
+from arcpy import SpatialReference, env
 from mock import patch
 from xxhash import xxh64
 
-from arcpy import SpatialReference, env
 from forklift.models import Crate, names_cache
 
 current_folder = path.dirname(path.abspath(__file__))

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -9,9 +9,9 @@ A module for testing lift.py
 import unittest
 from os import path
 
+import arcpy
 from mock import Mock, patch
 
-import arcpy
 from forklift import core, engine, lift
 from forklift.models import Crate, Pallet
 
@@ -118,6 +118,7 @@ class TestLift(unittest.TestCase):
         import arcpy
 
         def modify_workspace(value):
+            # pylint: disable-next=assigning-non-slot
             arcpy.env.workspace = value
 
         # pylint: disable=assignment-from-no-return


### PR DESCRIPTION
## Description of Changes
I believe that before this change, you had to have an options prop even if you had no servers.

### Test results and coverage
<!--
from ./
python setup.py develop && pytest
-->

```
============================================================== test session starts ===============================================================
platform win32 -- Python 3.9.11, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: C:\projects\forklift, configfile: pytest.ini, testpaths: tests
plugins: cov-3.0.0, instafail-0.4.2, isort-2.0.0, pylint-0.19.0
collected 218 items                                                                                                                               
--------------------------------------------------------------------------------
Linting files
....................................
--------------------------------------------------------------------------------

tests\__init__.py ..                                                                                                                     [  2/218]
tests\PalletWithSyntaxErrors.py ..                                                                                                       [  4/218]
tests\SchemaLockPallet.py ..                                                                                                             [  6/218]
tests\benchmark_arcgis.py ..                                                                                                             [  8/218]
tests\conftest.py ..                                                                                                                     [ 10/218]
tests\mocks.py ..                                                                                                                        [ 12/218]
tests\test_arcgis.py ...................                                                                                                 [ 31/218]
tests\test_change_detection.py ............                                                                                              [ 43/218]
tests\test_changes.py ........                                                                                                           [ 51/218]
tests\test_config.py .........                                                                                                           [ 60/218]
tests\test_core.py ........................................                                                                              [100/218]
tests\test_crate.py .....................                                                                                                [121/218]
tests\test_engine.py ........................s..........                                                                                 [156/218]
tests\test_lift.py ...........                                                                                                           [167/218]
tests\test_messaging.py .......                                                                                                          [174/218]
tests\test_pallet.py ..................................                                                                                  [208/218]
tests\test_seat.py ......                                                                                                                [214/218]
tests\test_slack.py ....                                                                                                                 [218/218]

================================================================ warnings summary ================================================================
..\..\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\site-packages\_pytest\config\__init__.py:1232
  C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\site-packages\_pytest\config\__init__.py:1232: PytestConfigWarning: Unknown config option: log_print

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/warnings.html

---------- coverage: platform win32, python 3.9.11-final-0 -----------
Name                               Stmts   Miss Branch BrPart     Cover   Missing
---------------------------------------------------------------------------------
src\forklift\arcgis.py               113     29     32      2    70.34%   26, 79-107, 137-138, 143, 146, 163, 181, 198-200, 222-224
src\forklift\change_detection.py      62      5     16      2    91.03%   32-34, 52, 55
src\forklift\config.py                52      1     20      2    95.83%   89, 124->123
src\forklift\core.py                 206      8    104     10    92.90%   98->168, 98->exit, 100, 130, 156-157, 169->98, 212->215, 275, 279-281, 299->304, 317->316, 444
src\forklift\engine.py               477    171    160     12    61.54%   136, 155-156, 221, 234-314, 318->364, 329-331, 354-355, 393-464, 494, 504, 518-534, 539-552, 568, 588, 607, 620-623, 663, 680-689, 720-721, 726, 740-746, 752, 759, 805, 910-953
src\forklift\lift.py                 148     52     52      4    61.00%   34, 42, 153-156, 163-164, 187-198, 233-254, 281, 285, 292-295, 310-317, 346-357
src\forklift\messaging.py             82     31     20      2    57.84%   56, 64-76, 88-123, 142, 163-169, 183-186
src\forklift\models.py               201      8     54      3    94.12%   97, 184->183, 409-414, 466-467
src\forklift\slack.py                212     33    102     33    75.80%   25-27, 57, 72-77, 80-85, 90->93, 101, 103, 105, 111->114, 117-118, 120->87, 137, 151->184, 155->158, 161-164, 165->168, 168->171, 174->177, 189->192, 195->197, 197->200, 202->205, 236, 260, 265, 276->278, 279, 284->287,
288, 305, 332, 334, 348, 351->354, 354->357, 360, 372, 375
---------------------------------------------------------------------------------
TOTAL                               1575    338    566     70    75.15%

3 files skipped due to complete coverage.

============================================= 217 passed, 1 skipped, 1 warning in 386.86s (0:06:26) ==============================================
```

### Speed test results
<!--
from ./src
python -m forklift speedtest
-->

```

```
