### PR TITLE
fix: add missing source field type

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -461,12 +461,15 @@ def _mirror_fields(source, destination):
         'BigInteger': 'BIGINTEGER',
         'Blob': 'BLOB',
         'Date': 'DATE',
+        'DateOnly': 'DATEONLY',
         'Double': 'DOUBLE',
         'Guid': 'GUID',
         'Integer': 'LONG',
         'Single': 'FLOAT',
         'SmallInteger': 'SHORT',
-        'String': 'TEXT'
+        'String': 'TEXT',
+        'TimeOnly': 'TIMEONLY',
+        'TimestampOffset': 'TIMESTAMPOFFSET'
     }
 
     add_fields = []

--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -458,6 +458,7 @@ def _mirror_fields(source, destination):
     adds all of the fields in source to destination
     '''
     TYPES = {
+        'BigInteger': 'BIGINTEGER',
         'Blob': 'BLOB',
         'Date': 'DATE',
         'Double': 'DOUBLE',


### PR DESCRIPTION
## Description of Changes
This is to handle a new field type that showed up after DEQ made a schema change. Here's the error message that I hope to solve with it:
```
DEBUG   01-09 01:46:45       core:   81 c:\forklift\data\hashed\deqquerylayers_temp.gdb\TRI does not exist. creating
WARNING 01-09 01:46:47       core:  284 creating new table: c:\forklift\data\hashed\deqquerylayers_temp.gdb\TRI
ERROR   01-09 01:46:52       core:  164 unhandled exception: 'BigInteger' for crate source: [c:\forklift\warehouse\deq-enviro\scripts\nightly\settings\..\databases\cercla.sde\cercla.Arcserver.PTN_TRI] source_workspace: [c:\forklift\warehouse\deq-enviro\scripts\nightly\settings\..\databases\cercla.sde] destination: [c:\forklift\data\hashed\deqquerylayers_temp.gdb\TRI]
Traceback (most recent call last):
  File "C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\site-packages\forklift\core.py", line 82, in update
    _create_destination_data(crate, skip_hash_field=change_detection.has_table(crate.source_name))
  File "C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\site-packages\forklift\core.py", line 286, in _create_destination_data
    _mirror_fields(crate.source, crate.destination)
  File "C:\Users\agrc-arcgis\AppData\Local\ESRI\conda\envs\forklift\lib\site-packages\forklift\core.py", line 476, in _mirror_fields
    add_fields.append([field.name, TYPES[field.type], field.aliasName, field.length])
KeyError: 'BigInteger'
DEBUG   01-09 01:46:52       lift:  106 finished crate 7625 ms
INFO    01-09 01:46:52       lift:  107 result: ('Unhandled exception during update.', "'BigInteger'")
```