### PR TITLE
fix: bump pyopenssl to remove conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'gitpython==3.*',
         'ndg-httpsclient==0.*',
         'pyasn1==0.*',
-        'pyopenssl==21.*',
+        'pyopenssl==23.*',
         'pystache==0.*',
         'requests==2.*',
         'sendgrid==6.*',


### PR DESCRIPTION
v21 was conflicting with the cryptography package which I think is a dependency of some of the pallets. Bumping to 23 fixes the issue. 

Ref: https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss