### PR TITLE
fix: add support for data with global id fields that does not use change detection

### DIFF
--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -482,6 +482,7 @@ def _mirror_fields(source, destination):
         "DateOnly": "DATEONLY",
         "Double": "DOUBLE",
         "Guid": "GUID",
+        "GlobalID": "GUID",
         "Integer": "LONG",
         "Single": "FLOAT",
         "SmallInteger": "SHORT",
@@ -492,7 +493,7 @@ def _mirror_fields(source, destination):
 
     add_fields = []
     for field in arcpy.da.Describe(source)["fields"]:
-        if field.type in ["OID", "GlobalID"]:
+        if field.type == "OID":
             continue
 
         add_fields.append([field.name, TYPES[field.type], field.aliasName, field.length])

--- a/src/forklift/core.py
+++ b/src/forklift/core.py
@@ -105,6 +105,7 @@ def update(crate, validate_crate, change_detection):
         if changes.has_changes():
             if "hasGlobalID" in crate.source_describe and crate.source_describe["hasGlobalID"]:
                 update_while_preserving_global_ids(crate)
+                change_status = (Crate.UPDATED, None)
             else:
                 log.debug("starting edit session...")
                 with arcpy.da.Editor(crate.destination_workspace):


### PR DESCRIPTION
## Description of Changes

This pull request fixes the following errors that have started showing up in the past few weeks:

It also fixes a bug where a crate that has data with a global id field would never be marked as updated.

Note: This is almost an exact revert of: https://github.com/agrc/forklift/pull/198/commits/5c3c6b48998d577a1f70776cd9900644d652820e

This was before we had a truncate and load solution for datasets with global id fields.
### Test results and coverage

<!--
pytest
-->

```
---------- coverage: platform win32, python 3.11.8-final-0 -----------
Name                               Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------
src\forklift\__init__.py               0      0      0      0   100%
src\forklift\arcgis.py               120     32     38      3    69%
src\forklift\change_detection.py      66      6     28      3    90%
src\forklift\config.py                56      1     28      2    96%
src\forklift\core.py                 253     17    134     14    91%
src\forklift\engine.py               549    205    220     20    60%
src\forklift\exceptions.py             3      0      0      0   100%
src\forklift\lift.py                 162     49     72      5    68%
src\forklift\messaging.py             98     43     34      3    52%
src\forklift\models.py               216     11     60      3    93%
src\forklift\seat.py                  19      0      6      0   100%
src\forklift\slack.py                216     35    106     33    76%
--------------------------------------------------------------------
TOTAL                               1758    399    726     86    74%
Coverage XML written to file cov.xml

=================================== 181 passed, 1 skipped, 19 warnings in 216.64s (0:03:36) ============
========================
```

### Speed test results

<!--
forklift speedtest
-->

```

```
