### PR TITLE
Avoid divide-by-zero when there is no packing list

### DIFF
--- a/src/forklift/slack.py
+++ b/src/forklift/slack.py
@@ -50,7 +50,8 @@ def lift_report_to_blocks(report):
 
     message.add(SectionBlock(":tractor:       :package: *Forklift Lift Report* :package:      :tractor:"))
 
-    percent = _safely_access(report, "num_success_pallets") / _safely_access(report, "total_pallets") * 100
+    total_pallets = _safely_access(report, "total_pallets")
+    percent = _safely_access(report, "num_success_pallets") / total_pallets * 100 if total_pallets else 100
     if percent == 100:
         percent = ":100:"
     else:
@@ -137,7 +138,8 @@ def ship_report_to_blocks(report):
 
     message.add(SectionBlock(":tractor:       :rocket: *Forklift Ship Report* :rocket:      :tractor:"))
 
-    percent = _safely_access(report, "num_success_pallets") / _safely_access(report, "total_pallets") * 100
+    total_pallets = _safely_access(report, "total_pallets")
+    percent = _safely_access(report, "num_success_pallets") / total_pallets * 100 if total_pallets else 100
     if percent == 100:
         percent = ":100:"
     else:

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -48,6 +48,38 @@ class TestSlack(unittest.TestCase):
 
         self.assertTrue(len(messages) == 1)
 
+    def test_ship_with_no_packing_list(self):
+        # total_pallets of 0 (no packing list) previously raised
+        # ZeroDivisionError when computing the success percentage. See #391.
+        messages = slack.ship_report_to_blocks(
+            {
+                "num_success_pallets": 0,
+                "total_pallets": 0,
+                "hostname": "testing",
+                "total_time": "1 second",
+                "server_reports": [],
+                "pallets": [],
+            }
+        )
+
+        self.assertTrue(len(messages) == 1)
+
+    def test_lift_with_no_packing_list(self):
+        # Same guard for the lift report path. See #391.
+        messages = slack.lift_report_to_blocks(
+            {
+                "num_success_pallets": 0,
+                "total_pallets": 0,
+                "hostname": "testing",
+                "total_time": "1 second",
+                "num_success_crates": 0,
+                "server_reports": [],
+                "pallets": [],
+            }
+        )
+
+        self.assertTrue(len(messages) == 1)
+
     def test_lift_with_error(self):
         messages = slack.lift_report_to_blocks(
             {


### PR DESCRIPTION
Fixes #391.

`lift_report_to_blocks` and `ship_report_to_blocks` compute the success percentage as `num_success_pallets / total_pallets * 100`. When a ship runs with no packing list, `total_pallets` is `0` (or missing, in which case `_safely_access` returns `None`), so this raises `ZeroDivisionError` / `TypeError` and the ship fails - the traceback in the issue points at `slack` line 140.

Both report paths now guard the division: when `total_pallets` is falsy the percentage is reported as `100` (no pallets means nothing failed, so the existing `:100:` path renders "0 of 0 pallets ran successfully"). I went with 100 rather than 0 since an empty run has no failures; happy to switch to 0 or a "no pallets" message if you prefer.

Added `test_ship_with_no_packing_list` and `test_lift_with_no_packing_list`. I could not run the suite locally because `forklift.models` imports `arcpy` (ArcGIS Pro, not installable outside an ArcGIS environment), so I verified the percentage logic standalone (`total=0` and `total=None` both yield `100`; normal ratios unchanged) and `py_compile`d the changed files. The new tests follow the existing `test_slack.py` structure and exercise the guarded path.